### PR TITLE
feat(mobile): add Create Habit screen

### DIFF
--- a/.github/scripts/setup-labels.sh
+++ b/.github/scripts/setup-labels.sh
@@ -1,25 +1,37 @@
 #!/usr/bin/env bash
-# Creates all labels defined in .github/labels.json
-# Requires: gh CLI (authenticated) and jq
+# Creates all labels for KIK48/New-Me
+# Requires: gh CLI (authenticated) — no jq needed
 set -e
 
 REPO="KIK48/New-Me"
-LABELS_FILE="$(dirname "$0")/../labels.json"
+
+create_or_update() {
+  local name="$1" color="$2" desc="$3"
+  if gh label list --repo "$REPO" --limit 100 | grep -q "^$name"; then
+    gh label edit "$name" --repo "$REPO" --color "$color" --description "$desc" 2>/dev/null \
+      && echo "  updated: $name" || echo "  skipped: $name"
+  else
+    gh label create "$name" --repo "$REPO" --color "$color" --description "$desc" \
+      && echo "  created: $name"
+  fi
+}
 
 echo "Setting up labels for $REPO ..."
 
-jq -c '.[]' "$LABELS_FILE" | while read -r label; do
-  name=$(echo "$label" | jq -r '.name')
-  color=$(echo "$label" | jq -r '.color')
-  desc=$(echo "$label" | jq -r '.description')
-
-  if gh label list --repo "$REPO" --limit 100 | grep -q "^$name"; then
-    gh label edit "$name" --repo "$REPO" --color "$color" --description "$desc" 2>/dev/null && \
-      echo "  updated: $name" || echo "  skipped: $name"
-  else
-    gh label create "$name" --repo "$REPO" --color "$color" --description "$desc" && \
-      echo "  created: $name"
-  fi
-done
+create_or_update "epic"            "7057ff" "Large body of work spanning multiple stories"
+create_or_update "story"           "0075ca" "Single deliverable within an epic"
+create_or_update "bug"             "d73a4a" "Something is broken"
+create_or_update "idea"            "cfd3d7" "Future feature idea, not yet scoped"
+create_or_update "phase-1"        "0e8a16" "Phase 1 — Core Tracker"
+create_or_update "phase-2"        "a2eeef" "Phase 2 — Reflection"
+create_or_update "phase-3"        "e4e669" "Phase 3 — Identity Mode"
+create_or_update "phase-4"        "f9d0c4" "Phase 4 — Growth Analytics"
+create_or_update "phase-5"        "fef2c0" "Phase 5 — Meet Past You"
+create_or_update "web"             "bfd4f2" "React/Vite web app"
+create_or_update "mobile"          "d4c5f9" "React Native mobile app"
+create_or_update "backend"         "f9a825" "Node/Express API"
+create_or_update "infra"           "b60205" "Infrastructure, DevOps, CI/CD"
+create_or_update "blocked"         "e4e669" "Cannot progress until something else is resolved"
+create_or_update "good first issue" "7fc97f" "Good for newcomers"
 
 echo "Done."

--- a/apps/mobile/src/api/client.ts
+++ b/apps/mobile/src/api/client.ts
@@ -1,0 +1,1 @@
+export const API_URL = 'https://new-me-l46q.onrender.com';

--- a/apps/mobile/src/navigation/RootNavigator.tsx
+++ b/apps/mobile/src/navigation/RootNavigator.tsx
@@ -4,23 +4,31 @@ import { useAuth } from "../context/AuthContext";
 import LoginScreen from "../screens/LoginScreen";
 import RegisterScreen from "../screens/RegisterScreen";
 import HabitsScreen from "../screens/HabitsScreen";
+import CreateHabitScreen from "../screens/CreateHabitScreen";
+import { AppStack, AuthStack } from "./types";
 
-const Stack = createNativeStackNavigator();
+const AuthNavigator = createNativeStackNavigator<AuthStack>();
+const AppNavigator = createNativeStackNavigator<AppStack>();
 
 export default function RootNavigator() {
   const { token } = useAuth();
   return (
     <NavigationContainer>
-      <Stack.Navigator>
-        {token ? (
-          <Stack.Screen name="Habits" component={HabitsScreen} />
-        ) : (
-          <>
-            <Stack.Screen name="Login" component={LoginScreen} />
-            <Stack.Screen name="Register" component={RegisterScreen} />
-          </>
-        )}
-      </Stack.Navigator>
+      {token ? (
+        <AppNavigator.Navigator>
+          <AppNavigator.Screen name="Habits" component={HabitsScreen} />
+          <AppNavigator.Screen
+            name="CreateHabit"
+            component={CreateHabitScreen}
+            options={{ title: "New Habit" }}
+          />
+        </AppNavigator.Navigator>
+      ) : (
+        <AuthNavigator.Navigator>
+          <AuthNavigator.Screen name="Login" component={LoginScreen} />
+          <AuthNavigator.Screen name="Register" component={RegisterScreen} />
+        </AuthNavigator.Navigator>
+      )}
     </NavigationContainer>
   );
 }

--- a/apps/mobile/src/navigation/types.tsx
+++ b/apps/mobile/src/navigation/types.tsx
@@ -2,3 +2,8 @@ export type AuthStack = {
   Login: undefined;
   Register: undefined;
 };
+
+export type AppStack = {
+  Habits: undefined;
+  CreateHabit: undefined;
+};

--- a/apps/mobile/src/screens/CreateHabitScreen.tsx
+++ b/apps/mobile/src/screens/CreateHabitScreen.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import {
+  View, Text, TextInput, TouchableOpacity,
+  StyleSheet, ActivityIndicator, Alert,
+} from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { AppStack } from '../navigation/types';
+import { useAuth } from '../context/AuthContext';
+import { API_URL } from '../api/client';
+
+type Props = NativeStackScreenProps<AppStack, 'CreateHabit'>;
+
+export default function CreateHabitScreen({ navigation }: Props) {
+  const { token } = useAuth();
+  const [name, setName] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function handleSave() {
+    if (!name.trim()) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`${API_URL}/habits`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ name: name.trim() }),
+      });
+      if (!res.ok) {
+        const body = await res.json();
+        Alert.alert('Error', body.error ?? 'Failed to create habit');
+        return;
+      }
+      navigation.goBack();
+    } catch {
+      Alert.alert('Error', 'Network error — try again');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>Habit Name</Text>
+      <TextInput
+        style={styles.input}
+        value={name}
+        onChangeText={setName}
+        placeholder="e.g. Read for 20 minutes"
+        autoFocus
+        returnKeyType="done"
+        onSubmitEditing={handleSave}
+      />
+      <TouchableOpacity
+        style={[styles.btn, !name.trim() && styles.btnDisabled]}
+        onPress={handleSave}
+        disabled={!name.trim() || loading}
+      >
+        {loading
+          ? <ActivityIndicator color="#fff" />
+          : <Text style={styles.btnText}>Save</Text>}
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 24, paddingTop: 40 },
+  label: { fontSize: 16, fontWeight: '600', marginBottom: 8 },
+  input: {
+    borderWidth: 1, borderColor: '#ddd', borderRadius: 8,
+    padding: 12, fontSize: 16, marginBottom: 24,
+  },
+  btn: {
+    backgroundColor: '#000', padding: 16, borderRadius: 8, alignItems: 'center',
+  },
+  btnDisabled: { backgroundColor: '#ccc' },
+  btnText: { color: '#fff', fontSize: 16, fontWeight: '600' },
+});

--- a/apps/mobile/src/screens/HabitsScreen.tsx
+++ b/apps/mobile/src/screens/HabitsScreen.tsx
@@ -1,29 +1,44 @@
 import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
-import React, {useState, useEffect} from 'react';
+import React, { useState, useCallback } from 'react';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useAuth } from '../context/AuthContext';
+import { AppStack } from '../navigation/types';
+import { API_URL } from '../api/client';
+
+type Nav = NativeStackNavigationProp<AppStack, 'Habits'>;
 
 export default function HabitsScreen() {
 
     const { token, logout} = useAuth();
+    const navigation = useNavigation<Nav>();
     const [habits, setHabits] = useState<any[]>([]);
 
-    useEffect(() => {
-        if (!token) return;
-        fetch('https://new-me-l46q.onrender.com/habits', {
-            headers: { Authorization: `Bearer ${token}` },
-        })
-        .then(res => res.json())
-        .then(data => setHabits(Array.isArray(data) ? data : []))
-        .catch(err => console.log('fetch error:', err));
-    }, [token]);
+    // Refetch every time this screen comes into focus (e.g. returning from CreateHabit)
+    useFocusEffect(
+        useCallback(() => {
+            if (!token) return;
+            fetch(`${API_URL}/habits`, {
+                headers: { Authorization: `Bearer ${token}` },
+            })
+            .then(res => res.json())
+            .then(data => setHabits(Array.isArray(data) ? data : []))
+            .catch(err => console.log('fetch error:', err));
+        }, [token])
+    );
 
     return (
     <View style={styles.container}>
         <View style={styles.header}>
             <Text style={styles.title}>My Habbits</Text>
-            <TouchableOpacity onPress={logout}>
-                <Text style={styles.logout}>Log Out</Text>
-            </TouchableOpacity>
+            <View style={styles.headerActions}>
+                <TouchableOpacity onPress={() => navigation.navigate('CreateHabit')} style={styles.addBtn}>
+                    <Text style={styles.addBtnText}>+</Text>
+                </TouchableOpacity>
+                <TouchableOpacity onPress={logout}>
+                    <Text style={styles.logout}>Log Out</Text>
+                </TouchableOpacity>
+            </View>
         </View>
         <FlatList
             data={habits}
@@ -43,6 +58,9 @@ const styles = StyleSheet.create({
     header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom:
   24 },
     title: { fontSize: 28, fontWeight: 'bold' },
+    headerActions: { flexDirection: 'row', alignItems: 'center', gap: 16 },
+    addBtn: { width: 36, height: 36, borderRadius: 18, backgroundColor: '#000', alignItems: 'center', justifyContent: 'center' },
+    addBtnText: { color: '#fff', fontSize: 24, lineHeight: 28 },
     logout: { color: '#888', fontSize: 14 },
     habit: { padding: 16, borderWidth: 1, borderColor: '#eee', borderRadius: 8, marginBottom: 12 },
     habitName: { fontSize: 16 },


### PR DESCRIPTION
## Summary
- Add `CreateHabitScreen` with name input, loading state, and error handling
- Register `CreateHabit` in the typed `AppStack` navigator
- Add `+` button to `HabitsScreen` header that navigates to it
- Switch `HabitsScreen` to `useFocusEffect` so the list auto-refreshes on return
- Extract API base URL to `src/api/client.ts` to avoid repeating it across screens

## Closes
Closes #24 (Story: Add "Create Habit" screen/flow on mobile)
Part of Epic #23 (Mobile Habit Parity)

## Test plan
- [x] Tap `+` → Create Habit screen opens
- [x] Save with empty name is disabled
- [x] Save with a valid name calls `POST /habits` and returns to the list
- [x] New habit appears in the list immediately (no manual refresh needed)
- [x] Network error shows an alert, stays on the screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)