### PR TITLE
feat(mobile): add Edit Habit screen

### DIFF
--- a/apps/mobile/src/navigation/RootNavigator.tsx
+++ b/apps/mobile/src/navigation/RootNavigator.tsx
@@ -5,6 +5,7 @@ import LoginScreen from "../screens/LoginScreen";
 import RegisterScreen from "../screens/RegisterScreen";
 import HabitsScreen from "../screens/HabitsScreen";
 import CreateHabitScreen from "../screens/CreateHabitScreen";
+import EditHabitScreen from "../screens/EditHabitScreen";
 import { AppStack, AuthStack } from "./types";
 
 const AuthNavigator = createNativeStackNavigator<AuthStack>();
@@ -21,6 +22,11 @@ export default function RootNavigator() {
             name="CreateHabit"
             component={CreateHabitScreen}
             options={{ title: "New Habit" }}
+          />
+          <AppNavigator.Screen
+            name="EditHabit"
+            component={EditHabitScreen}
+            options={{ title: "Edit Habit" }}
           />
         </AppNavigator.Navigator>
       ) : (

--- a/apps/mobile/src/navigation/types.tsx
+++ b/apps/mobile/src/navigation/types.tsx
@@ -6,4 +6,5 @@ export type AuthStack = {
 export type AppStack = {
   Habits: undefined;
   CreateHabit: undefined;
+  EditHabit: { id: string; name: string; notes?: string | null };
 };

--- a/apps/mobile/src/screens/EditHabitScreen.tsx
+++ b/apps/mobile/src/screens/EditHabitScreen.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import {
+  View, Text, TextInput, TouchableOpacity,
+  StyleSheet, ActivityIndicator, Alert,
+} from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { AppStack } from '../navigation/types';
+import { useAuth } from '../context/AuthContext';
+import { API_URL } from '../api/client';
+
+type Props = NativeStackScreenProps<AppStack, 'EditHabit'>;
+
+export default function EditHabitScreen({ navigation, route }: Props) {
+  const { token } = useAuth();
+  const { id, name: initialName } = route.params;
+  const [name, setName] = useState(initialName);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSave() {
+    if (!name.trim()) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`${API_URL}/habits/${id}`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ name: name.trim() }),
+      });
+      if (!res.ok) {
+        const body = await res.json();
+        Alert.alert('Error', body.error ?? 'Failed to update habit');
+        return;
+      }
+      navigation.goBack();
+    } catch {
+      Alert.alert('Error', 'Network error — try again');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>Habit Name</Text>
+      <TextInput
+        style={styles.input}
+        value={name}
+        onChangeText={setName}
+        autoFocus
+        returnKeyType="done"
+        onSubmitEditing={handleSave}
+      />
+      <TouchableOpacity
+        style={[styles.btn, !name.trim() && styles.btnDisabled]}
+        onPress={handleSave}
+        disabled={!name.trim() || loading}
+      >
+        {loading
+          ? <ActivityIndicator color="#fff" />
+          : <Text style={styles.btnText}>Save</Text>}
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 24, paddingTop: 40 },
+  label: { fontSize: 16, fontWeight: '600', marginBottom: 8 },
+  input: {
+    borderWidth: 1, borderColor: '#ddd', borderRadius: 8,
+    padding: 12, fontSize: 16, marginBottom: 24,
+  },
+  btn: {
+    backgroundColor: '#000', padding: 16, borderRadius: 8, alignItems: 'center',
+  },
+  btnDisabled: { backgroundColor: '#ccc' },
+  btnText: { color: '#fff', fontSize: 16, fontWeight: '600' },
+});

--- a/apps/mobile/src/screens/HabitsScreen.tsx
+++ b/apps/mobile/src/screens/HabitsScreen.tsx
@@ -46,6 +46,9 @@ export default function HabitsScreen() {
             renderItem={({ item }) => (
                 <View style={styles.habit}>
                     <Text style={styles.habitName}>{item.name}</Text>
+                    <TouchableOpacity onPress={() => navigation.navigate('EditHabit', { id: item.id, name: item.name, notes: item.notes })}>
+                        <Text style={styles.editBtn}>Edit</Text>
+                    </TouchableOpacity>
                 </View>
             )}
         />
@@ -62,6 +65,7 @@ const styles = StyleSheet.create({
     addBtn: { width: 36, height: 36, borderRadius: 18, backgroundColor: '#000', alignItems: 'center', justifyContent: 'center' },
     addBtnText: { color: '#fff', fontSize: 24, lineHeight: 28 },
     logout: { color: '#888', fontSize: 14 },
-    habit: { padding: 16, borderWidth: 1, borderColor: '#eee', borderRadius: 8, marginBottom: 12 },
-    habitName: { fontSize: 16 },
+    habit: { padding: 16, borderWidth: 1, borderColor: '#eee', borderRadius: 8, marginBottom: 12, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+    habitName: { fontSize: 16, flex: 1 },
+    editBtn: { color: '#888', fontSize: 14 },
   });


### PR DESCRIPTION
## Summary
- Add `EditHabitScreen` pre-filled with the habit's current name
- Register `EditHabit` in the typed `AppStack` navigator
- Add an Edit button to each habit row in `HabitsScreen`
- No extra refresh logic needed — `useFocusEffect` (added in #29) handles it

## Closes
Closes #25 (Story: Add "Edit Habit" screen/flow on mobile)
Part of Epic #23 (Mobile Habit Parity)

## Note
This branch is based on `feat/mobile-create-habit` — merge #29 first, then this one.

## Test plan
- [x] Tap Edit on a habit → Edit Habit screen opens pre-filled with current name
- [x] Change the name and Save → calls `PUT /habits/:id`, returns to list
- [x] Updated name appears immediately in the list
- [x] Save with empty name is disabled
- [x] Cancel (back button) discards changes