### PR TITLE
feat(mobile): add daily check-in interaction

### DIFF
--- a/apps/mobile/src/screens/HabitsScreen.tsx
+++ b/apps/mobile/src/screens/HabitsScreen.tsx
@@ -15,24 +15,97 @@ import { API_URL } from "../api/client";
 
 type Nav = NativeStackNavigationProp<AppStack, "Habits">;
 
+type DayStatus = "UNSET" | "DONE" | "MISSED";
+
+function todayISO(): string {
+  return new Date().toISOString().split("T")[0];
+}
+
+function nextStatus(current: DayStatus): DayStatus {
+  if (current === "UNSET") return "DONE";
+  if (current === "DONE") return "MISSED";
+  return "UNSET";
+}
+
 export default function HabitsScreen() {
   const { token, logout } = useAuth();
   const navigation = useNavigation<Nav>();
   const [habits, setHabits] = useState<any[]>([]);
   const [deleteMode, setDeleteMode] = useState(false);
+  // Maps habitId -> today's status
+  const [todayStatuses, setTodayStatuses] = useState<Record<string, DayStatus>>({});
 
   // Refetch every time this screen comes into focus (e.g. returning from CreateHabit)
   useFocusEffect(
     useCallback(() => {
       if (!token) return;
-      fetch(`${API_URL}/habits`, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
-        .then((res) => res.json())
-        .then((data) => setHabits(Array.isArray(data) ? data : []))
+      const today = todayISO();
+
+      Promise.all([
+        fetch(`${API_URL}/habits`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }).then((r) => r.json()),
+        fetch(`${API_URL}/habit-days`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }).then((r) => r.json()),
+      ])
+        .then(([habitsData, daysData]) => {
+          setHabits(Array.isArray(habitsData) ? habitsData : []);
+
+          // Build a map of habitId -> status for today only
+          const map: Record<string, DayStatus> = {};
+          if (Array.isArray(daysData)) {
+            daysData
+              .filter((d: any) => d.date?.startsWith(today))
+              .forEach((d: any) => {
+                map[d.habitId] = d.status as DayStatus;
+              });
+          }
+          setTodayStatuses(map);
+        })
         .catch((err) => console.log("fetch error:", err));
     }, [token]),
   );
+
+  async function handleCheckIn(habitId: string) {
+    const current = todayStatuses[habitId] ?? "UNSET";
+    const next = nextStatus(current);
+    const today = todayISO();
+
+    // Optimistic update — update UI immediately, don't wait for server
+    setTodayStatuses((prev) => ({ ...prev, [habitId]: next }));
+
+    try {
+      const res = await fetch(`${API_URL}/habit-days`, {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ habitId, date: today, status: next }),
+      });
+      if (!res.ok) {
+        // Roll back on failure
+        setTodayStatuses((prev) => ({ ...prev, [habitId]: current }));
+        Alert.alert("Error", "Failed to save check-in");
+      }
+    } catch {
+      setTodayStatuses((prev) => ({ ...prev, [habitId]: current }));
+      Alert.alert("Error", "Network error — try again");
+    }
+  }
+
+  function statusStyle(status: DayStatus) {
+    if (status === "DONE") return [styles.statusBtn, styles.statusDone];
+    if (status === "MISSED") return [styles.statusBtn, styles.statusMissed];
+    return [styles.statusBtn, styles.statusUnset];
+  }
+
+  function statusLabel(status: DayStatus) {
+    if (status === "DONE") return "✓";
+    if (status === "MISSED") return "✗";
+    return "";
+  }
 
   return (
     <View style={styles.container}>
@@ -62,62 +135,71 @@ export default function HabitsScreen() {
       <FlatList
         data={habits}
         keyExtractor={(item) => item.id}
-        renderItem={({ item }) => (
-          <View style={styles.habit}>
-            <Text style={styles.habitName}>{item.name}</Text>
-            {!deleteMode ? (
+        renderItem={({ item }) => {
+          const status = todayStatuses[item.id] ?? "UNSET";
+          return (
+            <View style={styles.habit}>
               <TouchableOpacity
-                onPress={() =>
-                  navigation.navigate("EditHabit", {
-                    id: item.id,
-                    name: item.name,
-                    notes: item.notes,
-                  })
-                }
+                style={statusStyle(status)}
+                onPress={() => handleCheckIn(item.id)}
               >
-                <Text style={styles.editBtn}>Edit</Text>
+                <Text style={styles.statusLabel}>{statusLabel(status)}</Text>
               </TouchableOpacity>
-            ) : (
-              <TouchableOpacity
-                style={styles.addBtn}
-                onPress={() =>
-                  Alert.alert("Removing", "Are you sure you want to remove?", [
-                    { text: "Cancel" },
-                    {
-                      text: "Delete",
-                      onPress: async () => {
-                        try {
-                          const res = await fetch(
-                            `${API_URL}/habits/${item.id}`,
-                            {
-                              method: "DELETE",
-                              headers: {
-                                Authorization: `Bearer ${token}`,
+              <Text style={styles.habitName}>{item.name}</Text>
+              {!deleteMode ? (
+                <TouchableOpacity
+                  onPress={() =>
+                    navigation.navigate("EditHabit", {
+                      id: item.id,
+                      name: item.name,
+                      notes: item.notes,
+                    })
+                  }
+                >
+                  <Text style={styles.editBtn}>Edit</Text>
+                </TouchableOpacity>
+              ) : (
+                <TouchableOpacity
+                  style={styles.addBtn}
+                  onPress={() =>
+                    Alert.alert("Removing", "Are you sure you want to remove?", [
+                      { text: "Cancel" },
+                      {
+                        text: "Delete",
+                        onPress: async () => {
+                          try {
+                            const res = await fetch(
+                              `${API_URL}/habits/${item.id}`,
+                              {
+                                method: "DELETE",
+                                headers: {
+                                  Authorization: `Bearer ${token}`,
+                                },
                               },
-                            },
-                          );
-                          if (!res.ok) {
-                            const body = await res.json();
-                            Alert.alert(
-                              "Error",
-                              body.error ?? "Failed to update habit",
                             );
-                            return;
+                            if (!res.ok) {
+                              const body = await res.json();
+                              Alert.alert(
+                                "Error",
+                                body.error ?? "Failed to delete habit",
+                              );
+                              return;
+                            }
+                            setHabits(habits.filter((h) => h.id !== item.id));
+                          } catch {
+                            Alert.alert("Error", "Network error — try again");
                           }
-                          setHabits(habits.filter((h) => h.id !== item.id));
-                        } catch {
-                          Alert.alert("Error", "Network error — try again");
-                        }
+                        },
                       },
-                    },
-                  ])
-                }
-              >
-                <Text style={styles.editBtn}>X</Text>
-              </TouchableOpacity>
-            )}
-          </View>
-        )}
+                    ])
+                  }
+                >
+                  <Text style={styles.editBtn}>X</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+          );
+        }}
       />
     </View>
   );
@@ -150,9 +232,20 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     marginBottom: 12,
     flexDirection: "row",
-    justifyContent: "space-between",
     alignItems: "center",
+    gap: 12,
   },
   habitName: { fontSize: 16, flex: 1 },
   editBtn: { color: "#888", fontSize: 14 },
+  statusBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  statusUnset: { borderWidth: 2, borderColor: "#ddd" },
+  statusDone: { backgroundColor: "#22c55e" },
+  statusMissed: { backgroundColor: "#ef4444" },
+  statusLabel: { color: "#fff", fontSize: 16, fontWeight: "bold" },
 });


### PR DESCRIPTION
## Summary
- Add a status circle to each habit row — grey (UNSET), green ✓ (DONE), red ✗ (MISSED)
- Tapping cycles through: UNSET → DONE → MISSED → UNSET
- Optimistic update: UI changes immediately, rolls back if the API call fails
- On screen focus, fetches today's statuses from `GET /habit-days` and filters for today
- Saves via `PUT /habit-days` with the correct `DayStatus` enum values (`UNSET`/`DONE`/`MISSED`)

## Note on the web app
The web check-in currently uses mock data and does not save to the backend. This is the first client to correctly use `PUT /habit-days`.

## Closes
Closes #27 (Story: Add daily check-in interaction on mobile)
Part of Epic #23 (Mobile Habit Parity)

## Note
This branch is based on `feat/mobile-delete-habit` — merge #29, #30, #31 first.

## Test plan
- [x] Each habit row shows a grey circle on load
- [x] Habits with a saved status today load with the correct colour
- [x] Tap grey → turns green ✓
- [x] Tap green → turns red ✗
- [x] Tap red → returns to grey
- [x] Status persists after leaving and returning to the screen
- [x] Network failure rolls back the UI and shows an error alert