### PR TITLE
feat(mobile): bottom tab nav, week view, check-in, and audit docs

### DIFF
--- a/docs/mobile/requirements.md
+++ b/docs/mobile/requirements.md
@@ -8,27 +8,33 @@ Stack: React Native
 |---|---|
 | Registration | ✅ Working |
 | Login | ✅ Working |
-| Read/list habits | ✅ Working (read-only) |
-| Create habit | ❌ Not built |
-| Update habit | ❌ Not built |
-| Delete habit | ❌ Not built |
-| Daily check-in | ❌ Not built |
+| Read/list habits | ✅ Working |
+| Create habit | ✅ Working |
+| Update habit | ✅ Working |
+| Delete habit | ✅ Working |
+| Daily check-in (today) | ✅ Working |
+| Weekly check-in view | ✅ Working |
 
-## The Gap
+## Endpoint Verification Audit (Story #28)
 
-Mobile currently has **zero write capability** for habits. This is the active epic: **Mobile Habit Parity**.
+Completed as part of Mobile Habit Parity epic. All mobile API calls map to existing backend routes with correct payload shapes.
 
-## Requirements (Mobile Habit Parity epic)
+| Operation | Endpoint | Mobile payload | Status |
+|---|---|---|---|
+| List habits | `GET /habits` | — | ✅ |
+| Create habit | `POST /habits` | `{ name }` | ✅ |
+| Update habit | `PUT /habits/:id` | `{ name }` | ✅ |
+| Delete habit | `DELETE /habits/:id` | — | ✅ |
+| Get habit days | `GET /habit-days` | — | ✅ |
+| Save check-in | `PUT /habit-days` | `{ habitId, date, status }` | ✅ |
 
-To reach parity with web, mobile needs:
+**No duplicated validation logic on mobile.** The only client-side guard is blocking Save when the name field is empty — this is a UX guard, not business logic. All real validation (ownership, empty name, status enum) lives on the backend.
 
-- [ ] Create habit screen/flow (mirrors web's create form)
-- [ ] Edit habit screen/flow
-- [ ] Delete habit (with confirmation)
-- [ ] Daily check-in interaction — tap to cycle empty → checked → missed (or however web's grid logic works)
-- [ ] Same validation rules as web (keep them in sync, ideally enforced by the shared backend, not duplicated client-side logic)
+### Accepted discrepancy
 
-## Open Questions
+The backend accepts a `notes` field on `POST /habits` and `PUT /habits/:id`. Mobile does not expose this field. This is **explicitly accepted** — neither the web create form nor the mobile form expose notes yet. Tracked as a future story.
 
-- Should the check-in interaction on mobile be a tap-to-cycle, swipe, or long-press? Web uses a grid of boxes — what's the equivalent mobile-native gesture?
-- Is the mobile app using the same API client/SDK code as web, or duplicated fetch logic? (Worth checking — shared API logic reduces the parity gap permanently.)
+## Open Questions (resolved)
+
+- ~~Check-in interaction~~ — resolved: tap-to-cycle on both Home (today) and Week views.
+- ~~Shared API logic~~ — resolved: both clients call the same endpoints with the same payloads. No shared SDK; each client has its own fetch calls, which is acceptable at this scale.


### PR DESCRIPTION
## Summary
- Add bottom tab navigator with Home and Week tabs
- Home tab: today's habits with date displayed, check-in status circles
- Week tab: Mon–Sun grid per habit with tappable check-in cells and week navigation arrows
- Extract date helpers to `src/utils/dates.ts`
- CreateHabit and EditHabit sit above the tab bar on the AppStack so the tab bar hides during forms
- Update `docs/mobile/requirements.md` with current status and endpoint audit results

## Closes
Closes #27 (Daily check-in interaction)
Closes #28 (Endpoint verification audit)
Part of Epic #23 (Mobile Habit Parity)

## Note
This branch is based on `feat/mobile-delete-habit` — merge #29, #30, #31 first.

## Test plan
- [x] Bottom tab bar shows Home and Week
- [x] Home tab shows today's date under the title
- [x] Status circles cycle correctly and persist
- [x] Week tab shows Mon–Sun grid for current week
- [x] Week nav arrows step forward and backward
- [x] Tapping a cell in the week grid cycles and saves the status
- [x] CreateHabit and EditHabit hide the tab bar when open