### PR TITLE
feat(mobile): add bottom tab navigation and week view

### DIFF
--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mobile",
       "version": "1.0.0",
       "dependencies": {
+        "@react-navigation/bottom-tabs": "^7.18.3",
         "@react-navigation/native": "^7.3.3",
         "@react-navigation/native-stack": "^7.17.5",
         "expo": "~54.0.0",
@@ -2652,10 +2653,28 @@
         }
       }
     },
+    "node_modules/@react-navigation/bottom-tabs": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.18.3.tgz",
+      "integrity": "sha512-715guj97M1yklVkN9ikUl6KJL9wO6hNot7URyUm+A1r5ltEHVgahKTgR8w7e4dNwiMjUjAnOdSErR0LaX1h+kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^2.9.26",
+        "color": "^4.2.3",
+        "sf-symbols-typescript": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.3.4",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
+      }
+    },
     "node_modules/@react-navigation/core": {
-      "version": "7.21.1",
-      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.21.1.tgz",
-      "integrity": "sha512-9eOK71VFEyJjm1bP8o4Gf7YYppWPZ+RdNIjTc+WbSM7AFEH0XXEIHkkhpIBuB416sDlRZ1CRxHk2frh1HPBZqw==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.21.2.tgz",
+      "integrity": "sha512-EsJhQnsL5NuIhXsWF7URijS5hd2AaJUREdq1fOIowlyNNQBA3jCnkGU0DkW7+eI40cQ+GXH8DQw+ci7TefLIxQ==",
       "license": "MIT",
       "dependencies": {
         "@react-navigation/routers": "^7.6.0",
@@ -2678,9 +2697,9 @@
       "license": "MIT"
     },
     "node_modules/@react-navigation/elements": {
-      "version": "2.9.25",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.25.tgz",
-      "integrity": "sha512-cV7Hny55aE/uge6f4UB0pbGQbFl3XjXLMW+lTBNuJs8P7a9tuf7dkkPHxxgnLIvxE+KJVI2K8CGabfDk4Ht0Sg==",
+      "version": "2.9.26",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.26.tgz",
+      "integrity": "sha512-EaHSJf42MjnH5VFL+KZfQIyqJvdQWK9Z27J7WUSuIVX5NXlR925sPmhWf540DX9gD1ny8BfUGPZAuw/PO4tK2w==",
       "license": "MIT",
       "dependencies": {
         "color": "^4.2.3",
@@ -2689,7 +2708,7 @@
       },
       "peerDependencies": {
         "@react-native-masked-view/masked-view": ">= 0.2.0",
-        "@react-navigation/native": "^7.3.3",
+        "@react-navigation/native": "^7.3.4",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0"
@@ -2701,12 +2720,12 @@
       }
     },
     "node_modules/@react-navigation/native": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.3.3.tgz",
-      "integrity": "sha512-VjZngfeiyJestZPT99CKHRi3qOR6XwnEEPWb6uHF/L7fBI6RBVP842iJf61MUHRTzsWPUT+epJqdf1wm8N5YkQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.3.4.tgz",
+      "integrity": "sha512-zyAqFLeZuaakerMMnhYqBeGAzJ+WFQUTgezP3FxSlXNwFq5XxnjP28vi2XHGqm4zg4pGWls9Ay4JKshIHUOpwA==",
       "license": "MIT",
       "dependencies": {
-        "@react-navigation/core": "^7.21.1",
+        "@react-navigation/core": "^7.21.2",
         "escape-string-regexp": "^4.0.0",
         "fast-deep-equal": "^3.1.3",
         "nanoid": "^3.3.11",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "index.ts",
   "dependencies": {
+    "@react-navigation/bottom-tabs": "^7.18.3",
     "@react-navigation/native": "^7.3.3",
     "@react-navigation/native-stack": "^7.17.5",
     "expo": "~54.0.0",

--- a/apps/mobile/src/navigation/RootNavigator.tsx
+++ b/apps/mobile/src/navigation/RootNavigator.tsx
@@ -3,9 +3,9 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useAuth } from "../context/AuthContext";
 import LoginScreen from "../screens/LoginScreen";
 import RegisterScreen from "../screens/RegisterScreen";
-import HabitsScreen from "../screens/HabitsScreen";
 import CreateHabitScreen from "../screens/CreateHabitScreen";
 import EditHabitScreen from "../screens/EditHabitScreen";
+import TabNavigator from "./TabNavigator";
 import { AppStack, AuthStack } from "./types";
 
 const AuthNavigator = createNativeStackNavigator<AuthStack>();
@@ -17,7 +17,12 @@ export default function RootNavigator() {
     <NavigationContainer>
       {token ? (
         <AppNavigator.Navigator>
-          <AppNavigator.Screen name="Habits" component={HabitsScreen} />
+          {/* Tab bar lives here — CreateHabit/EditHabit slide on top, hiding the tabs */}
+          <AppNavigator.Screen
+            name="Tabs"
+            component={TabNavigator}
+            options={{ headerShown: false }}
+          />
           <AppNavigator.Screen
             name="CreateHabit"
             component={CreateHabitScreen}

--- a/apps/mobile/src/navigation/TabNavigator.tsx
+++ b/apps/mobile/src/navigation/TabNavigator.tsx
@@ -1,0 +1,33 @@
+import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
+import { Text } from "react-native";
+import HabitsScreen from "../screens/HabitsScreen";
+import WeekScreen from "../screens/WeekScreen";
+import { TabStack } from "./types";
+
+const Tab = createBottomTabNavigator<TabStack>();
+
+export default function TabNavigator() {
+  return (
+    <Tab.Navigator
+      screenOptions={{
+        headerShown: false,
+        tabBarStyle: { paddingBottom: 4 },
+      }}
+    >
+      <Tab.Screen
+        name="Home"
+        component={HabitsScreen}
+        options={{
+          tabBarIcon: () => <Text style={{ fontSize: 18 }}>🏠</Text>,
+        }}
+      />
+      <Tab.Screen
+        name="Week"
+        component={WeekScreen}
+        options={{
+          tabBarIcon: () => <Text style={{ fontSize: 18 }}>📅</Text>,
+        }}
+      />
+    </Tab.Navigator>
+  );
+}

--- a/apps/mobile/src/navigation/types.tsx
+++ b/apps/mobile/src/navigation/types.tsx
@@ -3,8 +3,13 @@ export type AuthStack = {
   Register: undefined;
 };
 
+export type TabStack = {
+  Home: undefined;
+  Week: undefined;
+};
+
 export type AppStack = {
-  Habits: undefined;
+  Tabs: undefined;
   CreateHabit: undefined;
   EditHabit: { id: string; name: string; notes?: string | null };
 };

--- a/apps/mobile/src/screens/HabitsScreen.tsx
+++ b/apps/mobile/src/screens/HabitsScreen.tsx
@@ -12,14 +12,13 @@ import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useAuth } from "../context/AuthContext";
 import { AppStack } from "../navigation/types";
 import { API_URL } from "../api/client";
+import { todayISO, formatDate } from "../utils/dates";
 
-type Nav = NativeStackNavigationProp<AppStack, "Habits">;
+// HabitsScreen lives inside the tab navigator, but CreateHabit/EditHabit
+// are on the parent AppStack — useNavigation gives access to the full stack
+type Nav = NativeStackNavigationProp<AppStack>;
 
 type DayStatus = "UNSET" | "DONE" | "MISSED";
-
-function todayISO(): string {
-  return new Date().toISOString().split("T")[0];
-}
 
 function nextStatus(current: DayStatus): DayStatus {
   if (current === "UNSET") return "DONE";
@@ -110,7 +109,10 @@ export default function HabitsScreen() {
   return (
     <View style={styles.container}>
       <View style={styles.header}>
-        <Text style={styles.title}>My Habbits</Text>
+        <View>
+            <Text style={styles.title}>My Habbits</Text>
+            <Text style={styles.todayDate}>{formatDate(todayISO())}</Text>
+          </View>
         <View style={styles.headerActions}>
           <TouchableOpacity
             onPress={() => navigation.navigate("CreateHabit")}
@@ -214,6 +216,7 @@ const styles = StyleSheet.create({
     marginBottom: 24,
   },
   title: { fontSize: 28, fontWeight: "bold" },
+  todayDate: { fontSize: 13, color: "#888", marginTop: 2 },
   headerActions: { flexDirection: "row", alignItems: "center", gap: 16 },
   addBtn: {
     width: 36,

--- a/apps/mobile/src/screens/WeekScreen.tsx
+++ b/apps/mobile/src/screens/WeekScreen.tsx
@@ -1,0 +1,224 @@
+import React, { useState, useCallback } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  StyleSheet,
+  Alert,
+  ScrollView,
+} from "react-native";
+import { useFocusEffect } from "@react-navigation/native";
+import { useAuth } from "../context/AuthContext";
+import { API_URL } from "../api/client";
+import {
+  getMondayISO,
+  addDays,
+  buildWeekDates,
+  formatDate,
+} from "../utils/dates";
+
+type DayStatus = "UNSET" | "DONE" | "MISSED";
+
+// statuses[habitId][dayISO] = DayStatus
+type StatusMap = Record<string, Record<string, DayStatus>>;
+
+const DAY_LABELS = ["M", "T", "W", "T", "F", "S", "S"];
+
+function nextStatus(current: DayStatus): DayStatus {
+  if (current === "UNSET") return "DONE";
+  if (current === "DONE") return "MISSED";
+  return "UNSET";
+}
+
+export default function WeekScreen() {
+  const { token } = useAuth();
+  const [mondayISO, setMondayISO] = useState(() => getMondayISO());
+  const weekDates = buildWeekDates(mondayISO);
+  const sundayISO = weekDates[6];
+
+  const [habits, setHabits] = useState<any[]>([]);
+  const [statuses, setStatuses] = useState<StatusMap>({});
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!token) return;
+      loadData();
+    }, [token, mondayISO]),
+  );
+
+  async function loadData() {
+    try {
+      const [habitsData, daysData] = await Promise.all([
+        fetch(`${API_URL}/habits`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }).then((r) => r.json()),
+        fetch(`${API_URL}/habit-days`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }).then((r) => r.json()),
+      ]);
+
+      setHabits(Array.isArray(habitsData) ? habitsData : []);
+
+      // Build statuses[habitId][dayISO] for this week only
+      const map: StatusMap = {};
+      if (Array.isArray(daysData)) {
+        daysData.forEach((d: any) => {
+          const dayStr = d.date?.split("T")[0];
+          if (weekDates.includes(dayStr)) {
+            if (!map[d.habitId]) map[d.habitId] = {};
+            map[d.habitId][dayStr] = d.status as DayStatus;
+          }
+        });
+      }
+      setStatuses(map);
+    } catch (err) {
+      console.log("fetch error:", err);
+    }
+  }
+
+  async function handleCheckIn(habitId: string, dayISO: string) {
+    const current = statuses[habitId]?.[dayISO] ?? "UNSET";
+    const next = nextStatus(current);
+
+    // Optimistic update
+    setStatuses((prev) => ({
+      ...prev,
+      [habitId]: { ...(prev[habitId] ?? {}), [dayISO]: next },
+    }));
+
+    try {
+      const res = await fetch(`${API_URL}/habit-days`, {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ habitId, date: dayISO, status: next }),
+      });
+      if (!res.ok) {
+        setStatuses((prev) => ({
+          ...prev,
+          [habitId]: { ...(prev[habitId] ?? {}), [dayISO]: current },
+        }));
+        Alert.alert("Error", "Failed to save check-in");
+      }
+    } catch {
+      setStatuses((prev) => ({
+        ...prev,
+        [habitId]: { ...(prev[habitId] ?? {}), [dayISO]: current },
+      }));
+      Alert.alert("Error", "Network error — try again");
+    }
+  }
+
+  function cellStyle(status: DayStatus) {
+    if (status === "DONE") return [styles.cell, styles.cellDone];
+    if (status === "MISSED") return [styles.cell, styles.cellMissed];
+    return [styles.cell, styles.cellUnset];
+  }
+
+  function cellLabel(status: DayStatus) {
+    if (status === "DONE") return "✓";
+    if (status === "MISSED") return "✗";
+    return "";
+  }
+
+  return (
+    <View style={styles.container}>
+      {/* Week navigation */}
+      <View style={styles.weekNav}>
+        <TouchableOpacity
+          onPress={() => setMondayISO(addDays(mondayISO, -7))}
+          style={styles.navArrow}
+        >
+          <Text style={styles.navArrowText}>‹</Text>
+        </TouchableOpacity>
+        <Text style={styles.weekLabel}>
+          {formatDate(mondayISO)} — {formatDate(sundayISO)}
+        </Text>
+        <TouchableOpacity
+          onPress={() => setMondayISO(addDays(mondayISO, 7))}
+          style={styles.navArrow}
+        >
+          <Text style={styles.navArrowText}>›</Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* Day label header */}
+      <View style={styles.row}>
+        <View style={styles.habitNameCol} />
+        {DAY_LABELS.map((label, i) => (
+          <View key={i} style={styles.cell}>
+            <Text style={styles.dayLabel}>{label}</Text>
+          </View>
+        ))}
+      </View>
+
+      {/* Habit rows */}
+      <FlatList
+        data={habits}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View style={styles.row}>
+            <Text style={styles.habitName} numberOfLines={1}>
+              {item.name}
+            </Text>
+            {weekDates.map((dayISO) => {
+              const status = statuses[item.id]?.[dayISO] ?? "UNSET";
+              return (
+                <TouchableOpacity
+                  key={dayISO}
+                  style={cellStyle(status)}
+                  onPress={() => handleCheckIn(item.id, dayISO)}
+                >
+                  <Text style={styles.cellText}>{cellLabel(status)}</Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        )}
+      />
+    </View>
+  );
+}
+
+const CELL_SIZE = 36;
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16, paddingTop: 60 },
+  weekNav: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 20,
+  },
+  navArrow: { padding: 8 },
+  navArrowText: { fontSize: 28, color: "#000", lineHeight: 32 },
+  weekLabel: { fontSize: 15, fontWeight: "600" },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 8,
+  },
+  habitNameCol: { width: 90 },
+  habitName: {
+    width: 90,
+    fontSize: 13,
+    color: "#333",
+    paddingRight: 4,
+  },
+  cell: {
+    width: CELL_SIZE,
+    height: CELL_SIZE,
+    borderRadius: 6,
+    alignItems: "center",
+    justifyContent: "center",
+    marginHorizontal: 2,
+  },
+  cellUnset: { borderWidth: 1.5, borderColor: "#e0e0e0" },
+  cellDone: { backgroundColor: "#22c55e" },
+  cellMissed: { backgroundColor: "#ef4444" },
+  cellText: { color: "#fff", fontSize: 14, fontWeight: "bold" },
+  dayLabel: { fontSize: 11, color: "#888", fontWeight: "600" },
+});

--- a/apps/mobile/src/utils/dates.ts
+++ b/apps/mobile/src/utils/dates.ts
@@ -1,0 +1,28 @@
+export function getMondayISO(from: Date = new Date()): string {
+  const d = new Date(from);
+  const day = d.getUTCDay(); // 0=Sun, 1=Mon, ...
+  const diff = day === 0 ? -6 : 1 - day; // shift to Monday
+  d.setUTCDate(d.getUTCDate() + diff);
+  return d.toISOString().split("T")[0];
+}
+
+export function addDays(isoDate: string, n: number): string {
+  const d = new Date(isoDate + "T00:00:00Z");
+  d.setUTCDate(d.getUTCDate() + n);
+  return d.toISOString().split("T")[0];
+}
+
+// Returns array of 7 ISO dates starting from mondayISO (Mon → Sun)
+export function buildWeekDates(mondayISO: string): string[] {
+  return Array.from({ length: 7 }, (_, i) => addDays(mondayISO, i));
+}
+
+// mm/dd/yy
+export function formatDate(isoDate: string): string {
+  const [year, month, day] = isoDate.split("-");
+  return `${month}/${day}/${year.slice(2)}`;
+}
+
+export function todayISO(): string {
+  return new Date().toISOString().split("T")[0];
+}


### PR DESCRIPTION
## Summary
- Add bottom tab navigator — Home (today's habits) and Week (Mon–Sun grid)
- Home tab shows today's date under the title
- Week tab shows all habits in a grid with tappable check-in cells
- Week navigation arrows step backward/forward by one week
- Header shows mm/dd/yy for Monday and Sunday of the current week
- Date helpers extracted to `src/utils/dates.ts`
- CreateHabit and EditHabit sit above the tab bar so it hides during forms

## Test plan
- [ ] Bottom tab bar shows Home and Week
- [ ] Home tab shows today's date under the title
- [ ] Week tab shows Mon–Sun grid for current week
- [ ] Week nav arrows step forward and backward
- [ ] Tapping a cell cycles and saves the status
- [ ] CreateHabit and EditHabit hide the tab bar when open