### PR TITLE
Home screen redesign, Calendar rebuild, multi-completion logging, OTA updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-New-Me is a monorepo habit tracking app with a weekly-view UI. Three workspaces:
-- `apps/web` — React 19 + Vite frontend (main feature area)
-- `apps/api` — Express 5 REST API (port 4000)
-- `packages/db` — Prisma + SQLite (better-sqlite3 adapter)
+New-Me is a monorepo habit tracking app. Four workspaces:
+- `apps/mobile` — React Native / Expo mobile app (primary active development area)
+- `apps/web` — React 19 + Vite frontend
+- `apps/api` — Express 5 REST API (port 4000), deployed on Render
+- `packages/db` — Prisma + PostgreSQL (NeonDB in production, SQLite for local dev)
 
 ## Context Files
 
@@ -36,6 +37,7 @@ Follow this every time the user says "submit", "release", "push to GitHub", or s
 4. **Open a PR** if not already open — include issue reference and test checklist.
 5. **Create GitHub release** with `gh release create vX.Y.Z` — mark as `--prerelease` until the PR is merged and tested on device; remove pre-release after testing.
 6. **Remind the user** whether this release needs a full **EAS Build** (added a native module → yes) or just an **EAS Update** (JS-only changes → fast OTA).
+7. **If this release is a full EAS Build** (native), also bump `LATEST_NATIVE_VERSION` on the Render API to match the new `app.json` version — the mobile app compares this against its own `runtimeVersion` on launch to show the "update via TestFlight" prompt. Skip this step for OTA-only releases.
 
 ### EAS cheat sheet (run from `apps/mobile/`)
 ```bash
@@ -45,6 +47,11 @@ eas build --platform ios --profile preview
 # OTA update — JS-only changes, lands in seconds
 eas update --branch preview --message "what changed"
 ```
+
+### Update mechanism (implemented)
+- `src/hooks/useAppUpdates.ts`, wired into `App.tsx`, runs on every launch:
+  - OTA (JS-only): checks `expo-updates` for a pending update and reloads immediately instead of waiting for the next cold start — fully silent, no TestFlight involved.
+  - Native: fetches `GET /app-version` from the API and compares `latestRuntimeVersion` against `Updates.runtimeVersion`; if behind, shows an `Alert.alert` prompting the user to open TestFlight (Apple doesn't allow silent native updates).
 
 ## Commands
 
@@ -205,6 +212,44 @@ Topics to explain when relevant:
 - **Platform-specific concerns** — iOS vs. Android differences, native modules
 
 Explain how mobile architecture differs from web architecture and where the same patterns apply.
+
+### Mobile App Conventions (`apps/mobile/`)
+
+**Navigation structure:**
+- `RootNavigator` → AuthStack (Login, Register) or AppStack
+- AppStack: Tabs (Home, Weekly, Profile) + stack screens (CreateHabit, EditHabit, HabitDetail)
+- CreateHabit uses `transparentModal` + `slide_from_bottom`. All stack screens use `headerShown: false` with custom back buttons.
+
+**Data fetching pattern — always use this:**
+```tsx
+import { useIsFocused } from "@react-navigation/native";
+const isFocused = useIsFocused();
+useEffect(() => {
+  if (!token || !isFocused) return;
+  // fetch data...
+}, [token, isFocused]); // add other deps (e.g. mondayISO) as needed
+```
+Do NOT use `useFocusEffect(useCallback(fn, [token]))` — it only fires on navigation events, not when the token loads from SecureStore after app restart, leaving the default tab with blank data.
+
+**Design system:**
+| Token | Value |
+|-------|-------|
+| Background | `#000603` |
+| Card surface | `#085331` |
+| Primary green (text/icons) | `#98FF9D` |
+| Active border/button | `#009951` |
+| Accent blue | `#98eaff` |
+| Muted green | `#3a7a5a` |
+| Danger | `#860000` |
+
+Card style: `borderRadius: 16`, shadow `{ width: -4, height: 4 }`, `shadowOpacity: 0.25–0.4`.
+
+**Key libraries:**
+- `react-native-gesture-handler` — Swipeable for swipe-to-delete; `GestureHandlerRootView` wraps `App.tsx`
+- `react-native-svg` — SVG icons via `src/components/HabitIcons.tsx`
+- `expo-secure-store` — JWT storage; token accessed via `useAuth()` from `src/context/AuthContext.tsx`
+
+**API:** Base URL from `EXPO_PUBLIC_API_URL` env var, exported from `src/api/client.ts`. All habit routes need `Authorization: Bearer <token>`.
 
 ## Project Safety
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -9,3 +9,9 @@ CORS_ORIGIN=http://localhost:5173
 
 # Port the API listens on — 4000 is the default if this is omitted
 PORT=4000
+
+# Latest native mobile app version (matches app.json "version" of the newest EAS Build) —
+# bump this by hand only when a native rebuild ships, NOT for OTA/JS-only releases.
+# The mobile app compares this against its own runtimeVersion to know when to tell the
+# user to go update via TestFlight, since Apple never allows silent native updates.
+LATEST_NATIVE_VERSION=1.1.0

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,6 +4,7 @@ import cors from "cors";
 
 import habitsRouter from "./routes/habits.routes";
 import habitDay from "./routes/habitDay.routes";
+import habitLog from "./routes/habitLog.routes";
 import authRouter from "./routes/auth.routes";
 import { requireAuth } from "./middleware/requireAuth";
 
@@ -15,12 +16,20 @@ app.use(express.json());
 
 app.get("/health", (_req, res) => res.json({ ok: true }));
 
+// Lets the mobile app tell "OTA JS update available" (handled silently by expo-updates)
+// apart from "native rebuild needed" (Apple only allows that via TestFlight, never OTA) —
+// LATEST_NATIVE_VERSION is bumped by hand only when a full EAS Build ships.
+app.get("/app-version", (_req, res) =>
+  res.json({ latestRuntimeVersion: process.env.LATEST_NATIVE_VERSION ?? "1.1.0" }),
+);
+
 // Public: no token needed to log in / register
 app.use("/auth", authRouter);
 
 // Protected: requireAuth middleware validates the JWT before every request
 app.use("/habits", requireAuth, habitsRouter);
 app.use("/habit-days", requireAuth, habitDay);
+app.use("/habit-logs", requireAuth, habitLog);
 
 const port = process.env.PORT ?? 4000;
 app.listen(port, () => console.log(`Server running on http://localhost:${port}`));

--- a/apps/api/src/routes/habitLog.routes.ts
+++ b/apps/api/src/routes/habitLog.routes.ts
@@ -1,0 +1,59 @@
+import { Router } from "express";
+import { prisma } from "../../../../packages/db/src/prisma";
+import type { AuthRequest } from "../middleware/requireAuth";
+
+const router = Router();
+
+// Helper: confirms the habit exists AND belongs to the current user.
+async function getOwnedHabit(habitId: string, userId: string) {
+  return prisma.habit.findFirst({ where: { id: habitId, userId } });
+}
+
+// CREATE a completion — one row per instance (e.g. "eat 2x/day" gets 2 rows in a day)
+router.post("/", async (req, res) => {
+  const { userId } = (req as AuthRequest).user;
+  const { habitId, loggedAt } = req.body;
+
+  if (!habitId || typeof habitId !== "string") {
+    return res.status(400).json({ error: "habitId is required" });
+  }
+
+  const habit = await getOwnedHabit(habitId, userId);
+  if (!habit) return res.status(404).json({ error: "Habit not found" });
+
+  const log = await prisma.habitLog.create({
+    data: {
+      habitId,
+      loggedAt: loggedAt ? new Date(loggedAt) : new Date(),
+    },
+  });
+
+  res.status(201).json(log);
+});
+
+// READ — only logs for habits owned by this user
+router.get("/", async (req, res) => {
+  const { userId } = (req as AuthRequest).user;
+
+  const logs = await prisma.habitLog.findMany({
+    where: { habit: { userId } },
+    orderBy: { loggedAt: "desc" },
+  });
+  res.json(logs);
+});
+
+// DELETE a single log entry (undo one completion) — user must own the parent habit
+router.delete("/:id", async (req, res) => {
+  const { userId } = (req as unknown as AuthRequest).user;
+  const { id } = req.params;
+
+  const log = await prisma.habitLog.findFirst({
+    where: { id, habit: { userId } },
+  });
+  if (!log) return res.status(404).json({ error: "Log not found" });
+
+  await prisma.habitLog.delete({ where: { id } });
+  res.status(204).send();
+});
+
+export default router;

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,10 +1,13 @@
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { AuthProvider } from './src/context/AuthContext';
 import RootNavigator from './src/navigation/RootNavigator';
 
 export default function App() {
   return (
-    <AuthProvider>
-      <RootNavigator />
-    </AuthProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <AuthProvider>
+        <RootNavigator />
+      </AuthProvider>
+    </GestureHandlerRootView>
   );
 }

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,8 +1,11 @@
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { AuthProvider } from './src/context/AuthContext';
 import RootNavigator from './src/navigation/RootNavigator';
+import { useAppUpdates } from './src/hooks/useAppUpdates';
 
 export default function App() {
+  useAppUpdates();
+
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <AuthProvider>

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -17,6 +17,7 @@
         "expo-updates": "~29.0.18",
         "react": "19.1.0",
         "react-native": "0.81.5",
+        "react-native-gesture-handler": "~2.28.0",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-svg": "15.12.1"
@@ -1598,6 +1599,18 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/@expo/cli": {
       "version": "54.0.25",
       "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.25.tgz",
@@ -2839,6 +2852,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -4766,6 +4785,21 @@
       "dependencies": {
         "hermes-estree": "0.29.1"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
@@ -6957,6 +6991,21 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-gesture-handler": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
+      "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-is-edge-to-edge": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -12,6 +12,7 @@
     "expo-updates": "~29.0.18",
     "react": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-gesture-handler": "~2.28.0",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-svg": "15.12.1"

--- a/apps/mobile/src/api/client.ts
+++ b/apps/mobile/src/api/client.ts
@@ -1,4 +1,4 @@
 // Set EXPO_PUBLIC_API_URL in apps/mobile/.env (gitignored).
 // Dev: your local IP. Prod EAS builds: set via EAS environment variables.
 export const API_URL =
-  process.env.EXPO_PUBLIC_API_URL ?? "https://new-me-l46q.onrender.com";
+  process.env.EXPO_PUBLIC_API_URL ?? process.env.EXPO_PUBLIC_REAL_API_URL;

--- a/apps/mobile/src/hooks/useAppUpdates.ts
+++ b/apps/mobile/src/hooks/useAppUpdates.ts
@@ -1,0 +1,57 @@
+import { useEffect } from "react";
+import { Alert, Linking } from "react-native";
+import * as Updates from "expo-updates";
+import { API_URL } from "../api/client";
+import { isNewerVersion } from "../utils/version";
+
+// JS-only changes (screens, UI, logic) ship as OTA updates. expo-updates already
+// downloads these silently on launch, but doesn't apply them until the NEXT cold
+// start — this forces an immediate reload so the user is never more than one
+// relaunch behind, with zero TestFlight involvement.
+async function applyOTAUpdateIfAvailable() {
+  if (__DEV__ || !Updates.isEnabled) return;
+  try {
+    const result = await Updates.checkForUpdateAsync();
+    if (result.isAvailable) {
+      await Updates.fetchUpdateAsync();
+      await Updates.reloadAsync();
+    }
+  } catch (err) {
+    console.log("OTA update check failed:", err);
+  }
+}
+
+// Native changes (new native module, SDK bump) can never be OTA'd — Apple only
+// allows a new binary through TestFlight, so the best we can do is tell the user.
+// LATEST_NATIVE_VERSION on the API is bumped by hand only on native releases, so
+// this stays silent for ordinary OTA-only releases.
+async function checkForNativeUpdate() {
+  // Meaningless during local dev — you're expected to be ahead of whatever's
+  // actually submitted, so comparing against "latest" here is just noise.
+  if (__DEV__) return;
+  try {
+    const res = await fetch(`${API_URL}/app-version`);
+    const data = await res.json();
+    const latest = data.latestRuntimeVersion as string | undefined;
+    const current = Updates.runtimeVersion;
+    if (!latest || !current || !isNewerVersion(latest, current)) return;
+
+    Alert.alert(
+      "Update Available",
+      "A new version of New Me is ready. Update via TestFlight to get the latest features.",
+      [
+        { text: "Later", style: "cancel" },
+        { text: "Open TestFlight", onPress: () => Linking.openURL("itms-beta://") },
+      ],
+    );
+  } catch (err) {
+    console.log("Native version check failed:", err);
+  }
+}
+
+export function useAppUpdates() {
+  useEffect(() => {
+    applyOTAUpdateIfAvailable();
+    checkForNativeUpdate();
+  }, []);
+}

--- a/apps/mobile/src/navigation/TabNavigator.tsx
+++ b/apps/mobile/src/navigation/TabNavigator.tsx
@@ -51,7 +51,7 @@ export default function TabNavigator() {
         name="Week"
         component={WeekScreen}
         options={{
-          tabBarLabel: "Weekly",
+          tabBarLabel: "Calendar",
           tabBarIcon: ({ color, size }) => (
             <Feather name="calendar" size={size} color={color} />
           ),

--- a/apps/mobile/src/screens/CreateHabitScreen.tsx
+++ b/apps/mobile/src/screens/CreateHabitScreen.tsx
@@ -91,6 +91,7 @@ export default function CreateHabitScreen({ navigation }: Props) {
           onChangeText={setName}
           placeholder="e.g. Read for 20 minutes"
           placeholderTextColor="#3a7a5a"
+          keyboardAppearance="dark"
           autoFocus
           returnKeyType="next"
           maxLength={80}
@@ -102,6 +103,7 @@ export default function CreateHabitScreen({ navigation }: Props) {
           onChangeText={setNotes}
           placeholder="Notes (optional)"
           placeholderTextColor="#3a7a5a"
+          keyboardAppearance="dark"
           returnKeyType="done"
           onSubmitEditing={handleSave}
           maxLength={200}

--- a/apps/mobile/src/screens/HabitsScreen.tsx
+++ b/apps/mobile/src/screens/HabitsScreen.tsx
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   Alert,
 } from "react-native";
+import { Swipeable } from "react-native-gesture-handler";
 import React, { useState, useCallback } from "react";
 import { useFocusEffect, useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
@@ -18,24 +19,17 @@ import { CheckIcon, XIcon } from "../components/HabitIcons";
 // HabitsScreen lives inside the tab navigator, but CreateHabit/EditHabit
 // are on the parent AppStack — useNavigation gives access to the full stack
 type Nav = NativeStackNavigationProp<AppStack>;
-
 type DayStatus = "UNSET" | "DONE" | "MISSED";
+type Mode = "+" | "-" | null;
 
-function nextStatus(current: DayStatus): DayStatus {
-  if (current === "UNSET") return "DONE";
-  if (current === "DONE") return "MISSED";
-  return "UNSET";
-}
 
 export default function HabitsScreen() {
   const { token } = useAuth();
   const navigation = useNavigation<Nav>();
   const [habits, setHabits] = useState<any[]>([]);
-  const [deleteMode, setDeleteMode] = useState(false);
-  // Maps habitId -> today's status
-  const [todayStatuses, setTodayStatuses] = useState<Record<string, DayStatus>>(
-    {},
-  );
+  const [todayStatuses, setTodayStatuses] = useState<Record<string, DayStatus>>({});
+  // +/- mode: tap a habit card to mark done (+) or undo (-)
+  const [mode, setMode] = useState<Mode>(null);
 
   // Refetch every time this screen comes into focus (e.g. returning from CreateHabit)
   useFocusEffect(
@@ -69,12 +63,11 @@ export default function HabitsScreen() {
     }, [token]),
   );
 
-  async function handleCheckIn(habitId: string) {
+  async function updateStatus(habitId: string, next: DayStatus) {
     const current = todayStatuses[habitId] ?? "UNSET";
-    const next = nextStatus(current);
     const today = todayISO();
 
-    // Optimistic update — update UI immediately, don't wait for server
+    // Optimistic update
     setTodayStatuses((prev) => ({ ...prev, [habitId]: next }));
 
     try {
@@ -87,7 +80,6 @@ export default function HabitsScreen() {
         body: JSON.stringify({ habitId, date: today, status: next }),
       });
       if (!res.ok) {
-        // Roll back on failure
         setTodayStatuses((prev) => ({ ...prev, [habitId]: current }));
         Alert.alert("Error", "Failed to save check-in");
       }
@@ -95,6 +87,53 @@ export default function HabitsScreen() {
       setTodayStatuses((prev) => ({ ...prev, [habitId]: current }));
       Alert.alert("Error", "Network error — try again");
     }
+  }
+
+  function handleCardPress(habitId: string) {
+    if (mode === "+") {
+      updateStatus(habitId, "DONE");
+    } else if (mode === "-") {
+      updateStatus(habitId, "UNSET");
+    } else {
+      // Default: toggle done on status icon tap
+      const current = todayStatuses[habitId] ?? "UNSET";
+      updateStatus(habitId, current === "DONE" ? "UNSET" : "DONE");
+    }
+  }
+
+  function handleToggleMissed(habitId: string) {
+    const current = todayStatuses[habitId] ?? "UNSET";
+    updateStatus(habitId, current === "MISSED" ? "UNSET" : "MISSED");
+  }
+
+  function handleDelete(habitId: string) {
+    Alert.alert("Remove Habit", "Are you sure?", [
+      { text: "Cancel" },
+      {
+        text: "Delete",
+        style: "destructive",
+        onPress: async () => {
+          try {
+            const res = await fetch(`${API_URL}/habits/${habitId}`, {
+              method: "DELETE",
+              headers: { Authorization: `Bearer ${token}` },
+            });
+            if (!res.ok) {
+              const body = await res.json();
+              Alert.alert("Error", body.error ?? "Failed to delete");
+              return;
+            }
+            setHabits((prev) => prev.filter((h) => h.id !== habitId));
+          } catch {
+            Alert.alert("Error", "Network error — try again");
+          }
+        },
+      },
+    ]);
+  }
+
+  function toggleMode(next: Mode) {
+    setMode((prev) => (prev === next ? null : next));
   }
 
   const done = habits.filter((h) => todayStatuses[h.id] === "DONE").length;
@@ -115,21 +154,18 @@ export default function HabitsScreen() {
         </View>
         <View style={styles.headerRight}>
           <TouchableOpacity
-            style={styles.iconBtn}
-            onPress={() => navigation.navigate("CreateHabit")}
+            style={[styles.modeBtn, mode === "+" && styles.modeBtnPlus]}
+            onPress={() => toggleMode("+")}
           >
-            <Text style={styles.iconBtnText}>+</Text>
+            <Text style={[styles.modeBtnText, mode === "+" && styles.modeBtnTextPlus]}>
+              +
+            </Text>
           </TouchableOpacity>
           <TouchableOpacity
-            style={[styles.iconBtn, deleteMode && styles.iconBtnDanger]}
-            onPress={() => setDeleteMode(!deleteMode)}
+            style={[styles.modeBtn, mode === "-" && styles.modeBtnMinus]}
+            onPress={() => toggleMode("-")}
           >
-            <Text
-              style={[
-                styles.iconBtnText,
-                deleteMode && styles.iconBtnTextDanger,
-              ]}
-            >
+            <Text style={[styles.modeBtnText, mode === "-" && styles.modeBtnTextMinus]}>
               −
             </Text>
           </TouchableOpacity>
@@ -154,6 +190,15 @@ export default function HabitsScreen() {
         data={habits}
         keyExtractor={(item) => item.id}
         contentContainerStyle={styles.list}
+        ListFooterComponent={
+          <TouchableOpacity
+            style={styles.skeletonCard}
+            onPress={() => navigation.navigate("CreateHabit")}
+          >
+            <Text style={styles.skeletonPlus}>+</Text>
+            <Text style={styles.skeletonText}>Add new habit</Text>
+          </TouchableOpacity>
+        }
         renderItem={({ item }) => {
           const status = todayStatuses[item.id] ?? "UNSET";
           const nameColor =
@@ -163,97 +208,90 @@ export default function HabitsScreen() {
                 ? "#ff5555"
                 : "#98eaff";
           const subtext =
-            status === "DONE"
-              ? "Completed"
-              : status === "MISSED"
-                ? "Missed"
-                : "Tap to mark done";
+            mode === "+"
+              ? "Tap to mark done"
+              : mode === "-"
+                ? "Tap to undo"
+                : status === "DONE"
+                  ? "Completed"
+                  : status === "MISSED"
+                    ? "Missed"
+                    : "Tap to mark done";
 
           return (
-            <View style={styles.habitCard}>
-              <TouchableOpacity
-                style={styles.statusIcon}
-                onPress={() => handleCheckIn(item.id)}
-              >
-                {status === "DONE" && <CheckIcon size={40} />}
-                {status === "MISSED" && <XIcon size={40} />}
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={styles.habitInfo}
-                onPress={() =>
-                  navigation.navigate("HabitDetail", {
-                    id: item.id,
-                    name: item.name,
-                    notes: item.notes,
-                    frequency: { type: item.frequencyType ?? "DAILY", count: item.frequencyCount ?? 1 },
-                  })
-                }
-              >
-                <Text
-                  style={[
-                    styles.habitName,
-                    {
-                      color: nameColor,
-                      textDecorationLine:
-                        status === "MISSED" ? "line-through" : "none",
-                    },
-                  ]}
-                >
-                  {item.name}
-                </Text>
-                <Text style={styles.habitSub}>{subtext}</Text>
-              </TouchableOpacity>
-              {!deleteMode ? (
+            <Swipeable
+              renderRightActions={() => (
                 <TouchableOpacity
-                  onPress={() =>
-                    navigation.navigate("EditHabit", {
-                      id: item.id,
-                      name: item.name,
-                      notes: item.notes,
-                      frequency: { type: item.frequencyType ?? "DAILY", count: item.frequencyCount ?? 1 },
-                    })
-                  }
+                  style={swipeDeleteBtn}
+                  onPress={() => handleDelete(item.id)}
                 >
-                  <Text style={styles.editText}>Edit</Text>
-                </TouchableOpacity>
-              ) : (
-                <TouchableOpacity
-                  onPress={() =>
-                    Alert.alert("Remove Habit", "Are you sure?", [
-                      { text: "Cancel" },
-                      {
-                        text: "Delete",
-                        style: "destructive",
-                        onPress: async () => {
-                          try {
-                            const res = await fetch(
-                              `${API_URL}/habits/${item.id}`,
-                              {
-                                method: "DELETE",
-                                headers: { Authorization: `Bearer ${token}` },
-                              },
-                            );
-                            if (!res.ok) {
-                              const body = await res.json();
-                              Alert.alert(
-                                "Error",
-                                body.error ?? "Failed to delete",
-                              );
-                              return;
-                            }
-                            setHabits(habits.filter((h) => h.id !== item.id));
-                          } catch {
-                            Alert.alert("Error", "Network error — try again");
-                          }
-                        },
-                      },
-                    ])
-                  }
-                >
-                  <Text style={styles.deleteText}>✕</Text>
+                  <Text style={swipeDeleteText}>Delete</Text>
                 </TouchableOpacity>
               )}
-            </View>
+            >
+              <TouchableOpacity
+                style={styles.habitCard}
+                onPress={() => handleCardPress(item.id)}
+                activeOpacity={mode ? 0.6 : 1}
+              >
+                <View
+                  style={[
+                    styles.statusIcon,
+                    status === "DONE" && styles.statusIconDone,
+                    status === "MISSED" && styles.statusIconMissed,
+                  ]}
+                >
+                  {status === "DONE" && <CheckIcon size={40} />}
+                  {status === "MISSED" && <XIcon size={40} />}
+                </View>
+                <TouchableOpacity
+                  style={styles.habitInfo}
+                  onPress={() =>
+                    mode
+                      ? handleCardPress(item.id)
+                      : navigation.navigate("HabitDetail", {
+                          id: item.id,
+                          name: item.name,
+                          notes: item.notes,
+                          frequency: {
+                            type: item.frequencyType ?? "DAILY",
+                            count: item.frequencyCount ?? 1,
+                          },
+                        })
+                  }
+                >
+                  <Text
+                    style={[
+                      styles.habitName,
+                      {
+                        color: nameColor,
+                        textDecorationLine:
+                          status === "MISSED" ? "line-through" : "none",
+                      },
+                    ]}
+                  >
+                    {item.name}
+                  </Text>
+                  <Text style={styles.habitSub}>{subtext}</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[
+                    styles.missedBtn,
+                    status === "MISSED" && styles.missedBtnActive,
+                  ]}
+                  onPress={() => handleToggleMissed(item.id)}
+                >
+                  <Text
+                    style={[
+                      styles.missedBtnText,
+                      status === "MISSED" && styles.missedBtnTextActive,
+                    ]}
+                  >
+                    {status === "MISSED" ? "Undo" : "Missed"}
+                  </Text>
+                </TouchableOpacity>
+              </TouchableOpacity>
+            </Swipeable>
           );
         }}
       />
@@ -288,10 +326,9 @@ const styles = StyleSheet.create({
   },
   headerRight: {
     flexDirection: "row",
-    alignItems: "center",
     gap: 10,
   },
-  iconBtn: {
+  modeBtn: {
     width: 38,
     height: 38,
     borderRadius: 19,
@@ -301,16 +338,23 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: "rgba(152,234,255,0.12)",
   },
-  iconBtnDanger: {
-    backgroundColor: "rgba(134,0,0,0.4)",
-    borderColor: "rgba(255,85,85,0.3)",
+  modeBtnPlus: {
+    backgroundColor: "rgba(0,153,81,0.3)",
+    borderColor: "#009951",
   },
-  iconBtnText: {
-    color: "#98eaff",
+  modeBtnMinus: {
+    backgroundColor: "rgba(134,0,0,0.3)",
+    borderColor: "#860000",
+  },
+  modeBtnText: {
+    color: "#3a7a5a",
     fontSize: 22,
     lineHeight: 26,
   },
-  iconBtnTextDanger: {
+  modeBtnTextPlus: {
+    color: "#98FF9D",
+  },
+  modeBtnTextMinus: {
     color: "#ff5555",
   },
   progressCard: {
@@ -380,9 +424,11 @@ const styles = StyleSheet.create({
     borderColor: "rgba(152,234,255,0.1)",
     flexShrink: 0,
   },
-  statusIconLabel: {
-    fontSize: 20,
-    fontWeight: "bold",
+  statusIconDone: {
+    borderColor: "#009951",
+  },
+  statusIconMissed: {
+    borderColor: "#860000",
   },
   habitInfo: {
     flex: 1,
@@ -396,12 +442,56 @@ const styles = StyleSheet.create({
     color: "#3a7a5a",
     marginTop: 2,
   },
-  editText: {
-    fontSize: 13,
-    color: "rgba(152,234,255,0.4)",
+  missedBtn: {
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "rgba(134,0,0,0.4)",
   },
-  deleteText: {
-    fontSize: 16,
+  missedBtnActive: {
+    backgroundColor: "rgba(134,0,0,0.2)",
+    borderColor: "#860000",
+  },
+  missedBtnText: {
+    fontSize: 12,
+    color: "rgba(255,85,85,0.5)",
+  },
+  missedBtnTextActive: {
     color: "#ff5555",
   },
+  skeletonCard: {
+    borderRadius: 16,
+    padding: 16,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    borderWidth: 1,
+    borderColor: "rgba(152,255,157,0.25)",
+    borderStyle: "dashed",
+  },
+  skeletonPlus: {
+    fontSize: 22,
+    color: "#98FF9D",
+    lineHeight: 26,
+  },
+  skeletonText: {
+    fontSize: 15,
+    color: "#98FF9D",
+  },
 });
+
+const swipeDeleteBtn = {
+  backgroundColor: "#860000",
+  justifyContent: "center" as const,
+  alignItems: "center" as const,
+  paddingHorizontal: 24,
+  borderRadius: 16,
+  marginLeft: 8,
+};
+
+const swipeDeleteText = {
+  color: "#fff",
+  fontSize: 13,
+  fontWeight: "600" as const,
+};

--- a/apps/mobile/src/screens/HabitsScreen.tsx
+++ b/apps/mobile/src/screens/HabitsScreen.tsx
@@ -7,8 +7,8 @@ import {
   Alert,
 } from "react-native";
 import { Swipeable } from "react-native-gesture-handler";
-import React, { useState, useCallback } from "react";
-import { useFocusEffect, useNavigation } from "@react-navigation/native";
+import React, { useState, useEffect } from "react";
+import { useIsFocused, useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useAuth } from "../context/AuthContext";
 import { AppStack } from "../navigation/types";
@@ -31,37 +31,39 @@ export default function HabitsScreen() {
   // +/- mode: tap a habit card to mark done (+) or undo (-)
   const [mode, setMode] = useState<Mode>(null);
 
-  // Refetch every time this screen comes into focus (e.g. returning from CreateHabit)
-  useFocusEffect(
-    useCallback(() => {
-      if (!token) return;
-      const today = todayISO();
+  const isFocused = useIsFocused();
 
-      Promise.all([
-        fetch(`${API_URL}/habits`, {
-          headers: { Authorization: `Bearer ${token}` },
-        }).then((r) => r.json()),
-        fetch(`${API_URL}/habit-days`, {
-          headers: { Authorization: `Bearer ${token}` },
-        }).then((r) => r.json()),
-      ])
-        .then(([habitsData, daysData]) => {
-          setHabits(Array.isArray(habitsData) ? habitsData : []);
+  // Refetch when token loads OR screen gains focus.
+  // useIsFocused + useEffect handles both: navigation events AND app restarts where
+  // the screen is already focused when the token loads from SecureStore.
+  useEffect(() => {
+    if (!token || !isFocused) return;
+    const today = todayISO();
 
-          // Build a map of habitId -> status for today only
-          const map: Record<string, DayStatus> = {};
-          if (Array.isArray(daysData)) {
-            daysData
-              .filter((d: any) => d.date?.startsWith(today))
-              .forEach((d: any) => {
-                map[d.habitId] = d.status as DayStatus;
-              });
-          }
-          setTodayStatuses(map);
-        })
-        .catch((err) => console.log("fetch error:", err));
-    }, [token]),
-  );
+    Promise.all([
+      fetch(`${API_URL}/habits`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }).then((r) => r.json()),
+      fetch(`${API_URL}/habit-days`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }).then((r) => r.json()),
+    ])
+      .then(([habitsData, daysData]) => {
+        setHabits(Array.isArray(habitsData) ? habitsData : []);
+
+        // Build a map of habitId -> status for today only
+        const map: Record<string, DayStatus> = {};
+        if (Array.isArray(daysData)) {
+          daysData
+            .filter((d: any) => d.date?.startsWith(today))
+            .forEach((d: any) => {
+              map[d.habitId] = d.status as DayStatus;
+            });
+        }
+        setTodayStatuses(map);
+      })
+      .catch((err) => console.log("fetch error:", err));
+  }, [token, isFocused]);
 
   async function updateStatus(habitId: string, next: DayStatus) {
     const current = todayStatuses[habitId] ?? "UNSET";

--- a/apps/mobile/src/screens/LoginScreen.tsx
+++ b/apps/mobile/src/screens/LoginScreen.tsx
@@ -65,6 +65,7 @@ export default function LoginScreen({ navigation }: Props) {
           style={styles.input}
           placeholder="Email"
           placeholderTextColor="#98EAFF"
+          keyboardAppearance="dark"
           value={email}
           onChangeText={setEmail}
           autoCapitalize="none"
@@ -73,6 +74,7 @@ export default function LoginScreen({ navigation }: Props) {
           style={styles.input}
           placeholder="Password"
           placeholderTextColor="#98EAFF"
+          keyboardAppearance="dark"
           value={password}
           onChangeText={setPassword}
           secureTextEntry

--- a/apps/mobile/src/screens/ProfileScreen.tsx
+++ b/apps/mobile/src/screens/ProfileScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import {
   View,
   Text,
@@ -6,7 +6,7 @@ import {
   TouchableOpacity,
   StyleSheet,
 } from "react-native";
-import { useFocusEffect } from "@react-navigation/native";
+import { useIsFocused } from "@react-navigation/native";
 import { useAuth } from "../context/AuthContext";
 import { API_URL } from "../api/client";
 import {
@@ -39,24 +39,24 @@ export default function ProfileScreen() {
   );
   const avatarLetter = email ? email[0].toUpperCase() : "?";
 
-  useFocusEffect(
-    useCallback(() => {
-      if (!token) return;
-      Promise.all([
-        fetch(`${API_URL}/habits`, {
-          headers: { Authorization: `Bearer ${token}` },
-        }).then((r) => r.json()),
-        fetch(`${API_URL}/habit-days`, {
-          headers: { Authorization: `Bearer ${token}` },
-        }).then((r) => r.json()),
-      ])
-        .then(([habitsData, daysData]) => {
-          setHabits(Array.isArray(habitsData) ? habitsData : []);
-          setAllDays(Array.isArray(daysData) ? daysData : []);
-        })
-        .catch(console.error);
-    }, [token]),
-  );
+  const isFocused = useIsFocused();
+
+  useEffect(() => {
+    if (!token || !isFocused) return;
+    Promise.all([
+      fetch(`${API_URL}/habits`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }).then((r) => r.json()),
+      fetch(`${API_URL}/habit-days`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }).then((r) => r.json()),
+    ])
+      .then(([habitsData, daysData]) => {
+        setHabits(Array.isArray(habitsData) ? habitsData : []);
+        setAllDays(Array.isArray(daysData) ? daysData : []);
+      })
+      .catch(console.error);
+  }, [token, isFocused]);
 
   // ── Real stats ────────────────────────────────────────────
   const today = todayISO();

--- a/apps/mobile/src/screens/RegisterScreen.tsx
+++ b/apps/mobile/src/screens/RegisterScreen.tsx
@@ -72,6 +72,7 @@ export default function RegisterScreen({ navigation }: Props) {
           style={styles.input}
           placeholder="Email"
           placeholderTextColor="#98EAFF"
+          keyboardAppearance="dark"
           value={email}
           onChangeText={setEmail}
           autoCapitalize="none"
@@ -80,6 +81,7 @@ export default function RegisterScreen({ navigation }: Props) {
           style={styles.input}
           placeholder="Password"
           placeholderTextColor="#98EAFF"
+          keyboardAppearance="dark"
           value={password}
           onChangeText={setPassword}
           secureTextEntry
@@ -88,6 +90,7 @@ export default function RegisterScreen({ navigation }: Props) {
           style={styles.input}
           placeholder="Confirm Password"
           placeholderTextColor="#98EAFF"
+          keyboardAppearance="dark"
           value={confirmPassword}
           onChangeText={setConfirmPassword}
           secureTextEntry

--- a/apps/mobile/src/screens/WeekScreen.tsx
+++ b/apps/mobile/src/screens/WeekScreen.tsx
@@ -1,91 +1,74 @@
-import React, { useState, useCallback } from "react";
-import {
-  View,
-  Text,
-  FlatList,
-  TouchableOpacity,
-  StyleSheet,
-  Alert,
-} from "react-native";
-import { useFocusEffect } from "@react-navigation/native";
+import React, { useState, useEffect } from "react";
+import { View, Text, TouchableOpacity, StyleSheet, Alert } from "react-native";
+import { useIsFocused } from "@react-navigation/native";
 import { useAuth } from "../context/AuthContext";
 import { API_URL } from "../api/client";
-import {
-  getMondayISO,
-  addDays,
-  buildWeekDates,
-  formatDate,
-  todayISO,
-} from "../utils/dates";
-import { CheckIcon, XIcon } from "../components/HabitIcons";
+import { addDays, addMonths, buildWeekDates, getMondayISO, todayISO } from "../utils/dates";
+import DailyView from "./week/DailyView";
+import WeeklyView from "./week/WeeklyView";
+import MonthlyView from "./week/MonthlyView";
+import YearlyView from "./week/YearlyView";
+import { DayStatus, Habit, HabitLogEntry, StatusMap, ViewMode } from "./week/types";
 
-type DayStatus = "UNSET" | "DONE" | "MISSED";
-
-// statuses[habitId][dayISO] = DayStatus
-type StatusMap = Record<string, Record<string, DayStatus>>;
-
-const DAY_LABELS = ["M", "Tu", "W", "Th", "F", "Sa", "Su"];
-
-function nextStatus(current: DayStatus): DayStatus {
-  if (current === "UNSET") return "DONE";
-  if (current === "DONE") return "MISSED";
-  return "UNSET";
-}
+const VIEW_OPTIONS: { key: ViewMode; label: string }[] = [
+  { key: "daily", label: "Day" },
+  { key: "weekly", label: "Week" },
+  { key: "monthly", label: "Month" },
+  { key: "yearly", label: "Year" },
+];
 
 export default function WeekScreen() {
   const { token } = useAuth();
-  const [mondayISO, setMondayISO] = useState(() => getMondayISO());
-  const weekDates = buildWeekDates(mondayISO);
-  const sundayISO = weekDates[6];
+  const isFocused = useIsFocused();
 
-  const [habits, setHabits] = useState<any[]>([]);
+  const [viewMode, setViewMode] = useState<ViewMode>("weekly");
+  const [habits, setHabits] = useState<Habit[]>([]);
   const [statuses, setStatuses] = useState<StatusMap>({});
+  const [logs, setLogs] = useState<HabitLogEntry[]>([]);
 
-  const today = todayISO();
-  const todayColIndex = weekDates.indexOf(today);
+  // Per-view navigation anchors — kept independent so switching views doesn't lose your place
+  const [selectedDateISO, setSelectedDateISO] = useState(() => todayISO());
+  const [mondayISO, setMondayISO] = useState(() => getMondayISO());
+  const now = new Date();
+  const [monthAnchor, setMonthAnchor] = useState({ year: now.getFullYear(), month: now.getMonth() + 1 });
+  const [yearAnchor, setYearAnchor] = useState(now.getFullYear());
 
-  useFocusEffect(
-    useCallback(() => {
-      if (!token) return;
-      loadData();
-    }, [token, mondayISO]),
-  );
+  // Fetches the full habit-day history once per focus/token change — Monthly and
+  // Yearly views need long-range data anyway, so all 4 views share one dataset.
+  useEffect(() => {
+    if (!token || !isFocused) return;
 
-  async function loadData() {
-    try {
-      const [habitsData, daysData] = await Promise.all([
-        fetch(`${API_URL}/habits`, {
-          headers: { Authorization: `Bearer ${token}` },
-        }).then((r) => r.json()),
-        fetch(`${API_URL}/habit-days`, {
-          headers: { Authorization: `Bearer ${token}` },
-        }).then((r) => r.json()),
-      ]);
+    Promise.all([
+      fetch(`${API_URL}/habits`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }).then((r) => r.json()),
+      fetch(`${API_URL}/habit-days`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }).then((r) => r.json()),
+      fetch(`${API_URL}/habit-logs`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }).then((r) => r.json()),
+    ])
+      .then(([habitsData, daysData, logsData]) => {
+        setHabits(Array.isArray(habitsData) ? habitsData : []);
 
-      setHabits(Array.isArray(habitsData) ? habitsData : []);
-
-      // Build statuses[habitId][dayISO] for this week only
-      const map: StatusMap = {};
-      if (Array.isArray(daysData)) {
-        daysData.forEach((d: any) => {
-          const dayStr = d.date?.split("T")[0];
-          if (weekDates.includes(dayStr)) {
+        const map: StatusMap = {};
+        if (Array.isArray(daysData)) {
+          daysData.forEach((d: any) => {
+            const dayStr = d.date?.split("T")[0];
             if (!map[d.habitId]) map[d.habitId] = {};
             map[d.habitId][dayStr] = d.status as DayStatus;
-          }
-        });
-      }
-      setStatuses(map);
-    } catch (err) {
-      console.log("fetch error:", err);
-    }
-  }
+          });
+        }
+        setStatuses(map);
+        setLogs(Array.isArray(logsData) ? logsData : []);
+      })
+      .catch((err) => console.log("fetch error:", err));
+  }, [token, isFocused]);
 
-  async function handleCheckIn(habitId: string, dayISO: string) {
+  async function handleCheckIn(habitId: string, dayISO: string, next: DayStatus) {
     const current = statuses[habitId]?.[dayISO] ?? "UNSET";
-    const next = nextStatus(current);
 
-    // Optimistic update
     setStatuses((prev) => ({
       ...prev,
       [habitId]: { ...(prev[habitId] ?? {}), [dayISO]: next },
@@ -116,92 +99,132 @@ export default function WeekScreen() {
     }
   }
 
+  function handleWeeklyCellPress(habitId: string, dayISO: string) {
+    const current = statuses[habitId]?.[dayISO] ?? "UNSET";
+    const next: DayStatus = current === "UNSET" ? "DONE" : current === "DONE" ? "MISSED" : "UNSET";
+    handleCheckIn(habitId, dayISO, next);
+  }
+
+  // For DAILY habits with frequencyCount > 1 (e.g. "eat 2x/day") — each tap adds
+  // one timestamped completion instead of toggling a single day-level status.
+  async function handleAddLog(habitId: string) {
+    const tempId = `temp-${Date.now()}`;
+    const optimisticLog: HabitLogEntry = { id: tempId, habitId, loggedAt: new Date().toISOString() };
+    setLogs((prev) => [optimisticLog, ...prev]);
+
+    try {
+      const res = await fetch(`${API_URL}/habit-logs`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ habitId }),
+      });
+      if (!res.ok) throw new Error("Failed to log");
+      const saved = await res.json();
+      setLogs((prev) => prev.map((l) => (l.id === tempId ? saved : l)));
+    } catch {
+      setLogs((prev) => prev.filter((l) => l.id !== tempId));
+      Alert.alert("Error", "Failed to save — try again");
+    }
+  }
+
+  async function handleDeleteLog(logId: string) {
+    const removed = logs.find((l) => l.id === logId);
+    setLogs((prev) => prev.filter((l) => l.id !== logId));
+
+    try {
+      const res = await fetch(`${API_URL}/habit-logs/${logId}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error("Failed to delete");
+    } catch {
+      if (removed) setLogs((prev) => [removed, ...prev]);
+      Alert.alert("Error", "Failed to undo — try again");
+    }
+  }
+
+  // Each view only shows habits whose rule actually lives in that scope —
+  // e.g. "gym 5x/week" is a WEEKLY habit and only appears in the Weekly view.
+  const dailyHabits = habits.filter((h) => (h.frequencyType ?? "DAILY") === "DAILY");
+  const weeklyHabits = habits.filter((h) => h.frequencyType === "WEEKLY");
+  const monthlyHabits = habits.filter((h) => h.frequencyType === "MONTHLY");
+  const yearlyHabits = habits.filter((h) => h.frequencyType === "YEARLY");
+
   return (
     <View style={styles.container}>
-      {/* Header */}
       <View style={styles.header}>
-        <View>
-          <Text style={styles.eyebrow}>WEEKLY</Text>
-          <Text style={styles.title}>Weekly</Text>
-        </View>
+        <Text style={styles.eyebrow}>CALENDAR</Text>
+        <Text style={styles.title}>Calendar</Text>
       </View>
 
-      {/* Date nav card */}
-      <View style={styles.dateCard}>
-        <View style={styles.dateRow}>
-          <View style={styles.datePill}>
-            <Text style={styles.datePillText}>{formatDate(mondayISO)}</Text>
-          </View>
+      <View style={styles.viewSwitcher}>
+        {VIEW_OPTIONS.map((opt) => (
           <TouchableOpacity
-            style={styles.arrowBtn}
-            onPress={() => setMondayISO(addDays(mondayISO, -7))}
+            key={opt.key}
+            style={[styles.viewPill, viewMode === opt.key && styles.viewPillActive]}
+            onPress={() => setViewMode(opt.key)}
           >
-            <Text style={styles.arrowText}>‹</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={styles.arrowBtn}
-            onPress={() => setMondayISO(addDays(mondayISO, 7))}
-          >
-            <Text style={styles.arrowText}>›</Text>
-          </TouchableOpacity>
-          <View style={styles.datePill}>
-            <Text style={styles.datePillText}>{formatDate(sundayISO)}</Text>
-          </View>
-        </View>
-
-        {/* Day headers — aligned to cells below */}
-        <View style={styles.dayHeaderRow}>
-          <View style={styles.habitNameCol} />
-          {DAY_LABELS.map((label, i) => (
-            <View key={i} style={styles.cellSlot}>
-              <Text
-                style={[
-                  styles.dayLabel,
-                  i === todayColIndex && styles.dayLabelToday,
-                ]}
-              >
-                {label}
-              </Text>
-            </View>
-          ))}
-        </View>
-      </View>
-
-      {/* Habit rows */}
-      <FlatList
-        data={habits}
-        keyExtractor={(item) => item.id}
-        contentContainerStyle={styles.list}
-        renderItem={({ item }) => (
-          <View style={styles.habitCard}>
-            <Text style={styles.habitName} numberOfLines={1}>
-              {item.name}
+            <Text style={[styles.viewPillText, viewMode === opt.key && styles.viewPillTextActive]}>
+              {opt.label}
             </Text>
-            <View style={styles.cellRow}>
-              {weekDates.map((dayISO, i) => {
-                const status = statuses[item.id]?.[dayISO] ?? "UNSET";
-                const isToday = i === todayColIndex;
+          </TouchableOpacity>
+        ))}
+      </View>
 
-                return (
-                  <TouchableOpacity
-                    key={dayISO}
-                    style={[styles.cell, isToday && styles.cellToday]}
-                    onPress={() => handleCheckIn(item.id, dayISO)}
-                  >
-                    {status === "DONE" && <CheckIcon size={30} />}
-                    {status === "MISSED" && <XIcon size={30} />}
-                  </TouchableOpacity>
-                );
-              })}
-            </View>
-          </View>
-        )}
-      />
+      {viewMode === "daily" && (
+        <DailyView
+          dateISO={selectedDateISO}
+          habits={dailyHabits}
+          statuses={statuses}
+          logs={logs}
+          onPrevDay={() => setSelectedDateISO((d) => addDays(d, -1))}
+          onNextDay={() => setSelectedDateISO((d) => addDays(d, 1))}
+          onCheckIn={(habitId, next) => handleCheckIn(habitId, selectedDateISO, next)}
+          onAddLog={handleAddLog}
+          onDeleteLog={handleDeleteLog}
+        />
+      )}
+
+      {viewMode === "weekly" && (
+        <WeeklyView
+          mondayISO={mondayISO}
+          weekDates={buildWeekDates(mondayISO)}
+          habits={weeklyHabits}
+          statuses={statuses}
+          onPrevWeek={() => setMondayISO((d) => addDays(d, -7))}
+          onNextWeek={() => setMondayISO((d) => addDays(d, 7))}
+          onCellPress={handleWeeklyCellPress}
+        />
+      )}
+
+      {viewMode === "monthly" && (
+        <MonthlyView
+          year={monthAnchor.year}
+          month={monthAnchor.month}
+          habits={monthlyHabits}
+          statuses={statuses}
+          onPrevMonth={() => setMonthAnchor((a) => addMonths(a.year, a.month, -1))}
+          onNextMonth={() => setMonthAnchor((a) => addMonths(a.year, a.month, 1))}
+          onCheckIn={handleCheckIn}
+        />
+      )}
+
+      {viewMode === "yearly" && (
+        <YearlyView
+          year={yearAnchor}
+          habits={yearlyHabits}
+          statuses={statuses}
+          onPrevYear={() => setYearAnchor((y) => y - 1)}
+          onNextYear={() => setYearAnchor((y) => y + 1)}
+          onCheckIn={handleCheckIn}
+        />
+      )}
     </View>
   );
 }
-
-const CELL_SIZE = 34;
 
 const styles = StyleSheet.create({
   container: {
@@ -225,120 +248,30 @@ const styles = StyleSheet.create({
     fontWeight: "400",
     color: "#98FF9D",
   },
-  dateCard: {
-    backgroundColor: "#085331",
-    borderRadius: 16,
+  viewSwitcher: {
+    flexDirection: "row",
     marginHorizontal: 16,
-    marginBottom: 12,
-    paddingTop: 10,
-    shadowColor: "#000",
-    shadowOffset: { width: -4, height: 4 },
-    shadowOpacity: 0.4,
-    shadowRadius: 12,
-    elevation: 6,
-  },
-  dateRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingHorizontal: 10,
-    gap: 8,
-    marginBottom: 8,
-  },
-  datePill: {
-    flex: 1,
-    backgroundColor: "#000",
-    borderRadius: 10,
-    paddingVertical: 8,
-    alignItems: "center",
-  },
-  datePillText: {
-    fontSize: 11,
-    color: "#98eaff",
-  },
-  arrowBtn: {
-    width: 34,
-    height: 34,
-    borderRadius: 17,
-    backgroundColor: "#000",
-    alignItems: "center",
-    justifyContent: "center",
-    flexShrink: 0,
-  },
-  arrowText: {
-    fontSize: 20,
-    color: "#98eaff",
-    lineHeight: 24,
-  },
-  dayHeaderRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingHorizontal: 12,
-    paddingBottom: 10,
-  },
-  habitNameCol: {
-    width: 80,
-    flexShrink: 0,
-  },
-  cellSlot: {
-    width: CELL_SIZE,
-    alignItems: "center",
-    marginHorizontal: 2,
-  },
-  dayLabel: {
-    fontSize: 11,
-    color: "#98eaff",
-    fontWeight: "400",
-  },
-  dayLabelToday: {
-    color: "#98FF9D",
-    fontWeight: "600",
-  },
-  list: {
-    paddingHorizontal: 16,
-    paddingBottom: 110,
-    gap: 8,
-  },
-  habitCard: {
+    marginBottom: 14,
     backgroundColor: "#085331",
     borderRadius: 14,
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-    flexDirection: "row",
-    alignItems: "center",
-    shadowColor: "#000",
-    shadowOffset: { width: -4, height: 4 },
-    shadowOpacity: 0.25,
-    shadowRadius: 4,
-    elevation: 3,
+    padding: 4,
+    gap: 4,
   },
-  habitName: {
-    width: 80,
-    fontSize: 13,
-    color: "#98eaff",
-    flexShrink: 0,
-    paddingRight: 4,
-  },
-  cellRow: {
-    flexDirection: "row",
+  viewPill: {
     flex: 1,
-    justifyContent: "space-between",
-  },
-  cell: {
-    width: CELL_SIZE,
-    height: CELL_SIZE,
-    borderRadius: 8,
-    backgroundColor: "#000",
+    paddingVertical: 8,
+    borderRadius: 10,
     alignItems: "center",
-    justifyContent: "center",
-    borderWidth: 1,
-    borderColor: "rgba(152,234,255,0.08)",
   },
-  cellToday: {
-    borderWidth: 1.5,
-    borderColor: "rgba(152,234,255,0.45)",
+  viewPillActive: {
+    backgroundColor: "#009951",
   },
-  cellLabel: {
-    fontSize: 14,
-    fontWeight: "bold",
+  viewPillText: {
+    fontSize: 13,
+    color: "#3a7a5a",
+  },
+  viewPillTextActive: {
+    color: "#98FF9D",
+    fontWeight: "600",
   },
 });

--- a/apps/mobile/src/screens/week/DailyView.tsx
+++ b/apps/mobile/src/screens/week/DailyView.tsx
@@ -1,0 +1,388 @@
+import React from "react";
+import { View, Text, FlatList, TouchableOpacity, StyleSheet } from "react-native";
+import { CheckIcon, XIcon } from "../../components/HabitIcons";
+import { formatTime, localDateOf, todayISO } from "../../utils/dates";
+import { DayStatus, Habit, HabitLogEntry, StatusMap } from "./types";
+
+interface Props {
+  dateISO: string;
+  habits: Habit[];
+  statuses: StatusMap;
+  logs: HabitLogEntry[];
+  onPrevDay: () => void;
+  onNextDay: () => void;
+  onCheckIn: (habitId: string, next: DayStatus) => void;
+  onAddLog: (habitId: string) => void;
+  onDeleteLog: (logId: string) => void;
+}
+
+export default function DailyView({
+  dateISO,
+  habits,
+  statuses,
+  logs,
+  onPrevDay,
+  onNextDay,
+  onCheckIn,
+  onAddLog,
+  onDeleteLog,
+}: Props) {
+  const today = todayISO();
+  const isToday = dateISO === today;
+  const canLogToday = dateISO === today; // "now" only makes sense for the day you're viewing
+  const dateLabel = new Date(dateISO + "T00:00:00").toLocaleDateString("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  });
+
+  function logsForHabitOnDate(habitId: string) {
+    return logs.filter((l) => l.habitId === habitId && localDateOf(l.loggedAt) === dateISO);
+  }
+
+  function isComplete(h: Habit) {
+    const target = h.frequencyCount ?? 1;
+    if (target > 1) return logsForHabitOnDate(h.id).length >= target;
+    return statuses[h.id]?.[dateISO] === "DONE";
+  }
+
+  const done = habits.filter(isComplete).length;
+  const pct = habits.length > 0 ? Math.round((done / habits.length) * 100) : 0;
+
+  return (
+    <View style={styles.wrap}>
+      <View style={styles.dateCard}>
+        <View style={styles.dateRow}>
+          <TouchableOpacity style={styles.arrowBtn} onPress={onPrevDay}>
+            <Text style={styles.arrowText}>‹</Text>
+          </TouchableOpacity>
+          <Text style={styles.dateLabel}>{isToday ? "Today" : dateLabel}</Text>
+          <TouchableOpacity style={styles.arrowBtn} onPress={onNextDay}>
+            <Text style={styles.arrowText}>›</Text>
+          </TouchableOpacity>
+        </View>
+        <View style={styles.progressRow}>
+          <View style={styles.progressTrack}>
+            <View style={[styles.progressFill, { width: `${pct}%` as any }]} />
+          </View>
+          <Text style={styles.progressCount}>
+            {done}/{habits.length}
+          </Text>
+        </View>
+      </View>
+
+      <FlatList
+        data={habits}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={styles.list}
+        renderItem={({ item }) => {
+          const target = item.frequencyCount ?? 1;
+
+          if (target > 1) {
+            const dayLogs = logsForHabitOnDate(item.id).sort((a, b) =>
+              a.loggedAt < b.loggedAt ? 1 : -1,
+            );
+            const count = dayLogs.length;
+            const barPct = Math.min(Math.round((count / target) * 100), 100);
+            const isFullyDone = count >= target;
+            const isMissed = statuses[item.id]?.[dateISO] === "MISSED";
+
+            return (
+              <View style={styles.multiCard}>
+                <View style={styles.cardTop}>
+                  <TouchableOpacity
+                    disabled={!canLogToday}
+                    style={[
+                      styles.statusIcon,
+                      isFullyDone && styles.statusIconDone,
+                      !isFullyDone && isMissed && styles.statusIconMissed,
+                    ]}
+                    onPress={() => onAddLog(item.id)}
+                  >
+                    {isFullyDone && <CheckIcon size={28} />}
+                    {!isFullyDone && isMissed && <XIcon size={28} />}
+                  </TouchableOpacity>
+                  <Text style={styles.habitName} numberOfLines={1}>
+                    {item.name}
+                  </Text>
+                  <Text style={styles.countText}>
+                    {count}/{target}
+                  </Text>
+                </View>
+                <View style={styles.barTrack}>
+                  <View style={[styles.barFill, { width: `${barPct}%` as any }]} />
+                </View>
+
+                {dayLogs.length > 0 && (
+                  <View style={styles.logRows}>
+                    {dayLogs.map((log) => (
+                      <View key={log.id} style={styles.logRow}>
+                        <Text style={styles.logTime}>{formatTime(log.loggedAt)}</Text>
+                        <TouchableOpacity onPress={() => onDeleteLog(log.id)}>
+                          <Text style={styles.logRemove}>Remove</Text>
+                        </TouchableOpacity>
+                      </View>
+                    ))}
+                  </View>
+                )}
+
+                <View style={styles.multiActionsRow}>
+                  {canLogToday && (
+                    <TouchableOpacity style={styles.addLogBtn} onPress={() => onAddLog(item.id)}>
+                      <Text style={styles.addLogText}>+ Log now</Text>
+                    </TouchableOpacity>
+                  )}
+                  <TouchableOpacity
+                    style={[styles.missedBtn, isMissed && styles.missedBtnActive]}
+                    onPress={() => onCheckIn(item.id, isMissed ? "UNSET" : "MISSED")}
+                  >
+                    <Text style={[styles.missedBtnText, isMissed && styles.missedBtnTextActive]}>
+                      {isMissed ? "Undo" : "Missed"}
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            );
+          }
+
+          const status = statuses[item.id]?.[dateISO] ?? "UNSET";
+          const nameColor =
+            status === "DONE" ? "#98FF9D" : status === "MISSED" ? "#ff5555" : "#98eaff";
+
+          return (
+            <TouchableOpacity
+              style={styles.habitCard}
+              onPress={() => onCheckIn(item.id, status === "DONE" ? "UNSET" : "DONE")}
+            >
+              <View
+                style={[
+                  styles.statusIcon,
+                  status === "DONE" && styles.statusIconDone,
+                  status === "MISSED" && styles.statusIconMissed,
+                ]}
+              >
+                {status === "DONE" && <CheckIcon size={36} />}
+                {status === "MISSED" && <XIcon size={36} />}
+              </View>
+              <Text
+                style={[
+                  styles.habitName,
+                  {
+                    color: nameColor,
+                    textDecorationLine: status === "MISSED" ? "line-through" : "none",
+                  },
+                ]}
+                numberOfLines={1}
+              >
+                {item.name}
+              </Text>
+              <TouchableOpacity
+                style={[styles.missedBtn, status === "MISSED" && styles.missedBtnActive]}
+                onPress={() => onCheckIn(item.id, status === "MISSED" ? "UNSET" : "MISSED")}
+              >
+                <Text
+                  style={[
+                    styles.missedBtnText,
+                    status === "MISSED" && styles.missedBtnTextActive,
+                  ]}
+                >
+                  {status === "MISSED" ? "Undo" : "Missed"}
+                </Text>
+              </TouchableOpacity>
+            </TouchableOpacity>
+          );
+        }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { flex: 1 },
+  dateCard: {
+    backgroundColor: "#085331",
+    borderRadius: 16,
+    marginHorizontal: 16,
+    marginBottom: 12,
+    padding: 16,
+    shadowColor: "#000",
+    shadowOffset: { width: -4, height: 4 },
+    shadowOpacity: 0.4,
+    shadowRadius: 12,
+    elevation: 6,
+  },
+  dateRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 12,
+  },
+  dateLabel: {
+    fontSize: 16,
+    color: "#98eaff",
+  },
+  arrowBtn: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    backgroundColor: "#000",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  arrowText: {
+    fontSize: 20,
+    color: "#98eaff",
+    lineHeight: 24,
+  },
+  progressRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  progressTrack: {
+    flex: 1,
+    height: 6,
+    borderRadius: 4,
+    backgroundColor: "rgba(0,0,0,0.4)",
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    borderRadius: 4,
+    backgroundColor: "#98FF9D",
+  },
+  progressCount: {
+    fontSize: 13,
+    color: "#98FF9D",
+  },
+  list: {
+    paddingHorizontal: 16,
+    paddingBottom: 110,
+    gap: 8,
+  },
+  habitCard: {
+    backgroundColor: "#085331",
+    borderRadius: 14,
+    padding: 12,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    shadowColor: "#000",
+    shadowOffset: { width: -4, height: 4 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  statusIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 8,
+    backgroundColor: "#000",
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 1,
+    borderColor: "rgba(152,234,255,0.1)",
+    flexShrink: 0,
+  },
+  statusIconDone: {
+    borderColor: "#009951",
+  },
+  statusIconMissed: {
+    borderColor: "#860000",
+  },
+  habitName: {
+    flex: 1,
+    fontSize: 15,
+    color: "#98eaff",
+  },
+  missedBtn: {
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "rgba(134,0,0,0.4)",
+  },
+  missedBtnActive: {
+    backgroundColor: "rgba(134,0,0,0.2)",
+    borderColor: "#860000",
+  },
+  missedBtnText: {
+    fontSize: 11,
+    color: "rgba(255,85,85,0.5)",
+  },
+  missedBtnTextActive: {
+    color: "#ff5555",
+  },
+  multiCard: {
+    backgroundColor: "#085331",
+    borderRadius: 14,
+    padding: 14,
+    shadowColor: "#000",
+    shadowOffset: { width: -4, height: 4 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  cardTop: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    marginBottom: 10,
+  },
+  multiActionsRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginTop: 10,
+  },
+  countText: {
+    fontSize: 14,
+    color: "#98FF9D",
+    fontWeight: "600",
+  },
+  barTrack: {
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: "rgba(0,0,0,0.4)",
+    overflow: "hidden",
+  },
+  barFill: {
+    height: "100%",
+    borderRadius: 4,
+    backgroundColor: "#009951",
+  },
+  logRows: {
+    marginTop: 10,
+    gap: 6,
+  },
+  logRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    backgroundColor: "#000",
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+  logTime: {
+    fontSize: 12,
+    color: "#98eaff",
+  },
+  logRemove: {
+    fontSize: 11,
+    color: "rgba(255,85,85,0.7)",
+  },
+  addLogBtn: {
+    alignSelf: "flex-start",
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#009951",
+  },
+  addLogText: {
+    fontSize: 12,
+    color: "#98FF9D",
+    fontWeight: "600",
+  },
+});

--- a/apps/mobile/src/screens/week/MonthlyView.tsx
+++ b/apps/mobile/src/screens/week/MonthlyView.tsx
@@ -1,0 +1,301 @@
+import React, { useState, useEffect } from "react";
+import { View, Text, FlatList, TouchableOpacity, StyleSheet } from "react-native";
+import { MONTH_ABBR, MONTH_LABELS, daysInMonth, todayISO } from "../../utils/dates";
+import { CheckIcon, XIcon } from "../../components/HabitIcons";
+import { DayStatus, Habit, StatusMap } from "./types";
+
+interface Props {
+  year: number;
+  month: number; // 1-indexed
+  habits: Habit[];
+  statuses: StatusMap;
+  onPrevMonth: () => void;
+  onNextMonth: () => void;
+  onCheckIn: (habitId: string, dateISO: string, next: DayStatus) => void;
+}
+
+// Defaults the log cursor to today (current month), or the last day of a past month —
+// there's no meaningful "today" to default to once you're browsing history.
+function defaultLogDay(year: number, month: number, today: string): number {
+  const [ty, tm] = today.split("-").map(Number);
+  if (year === ty && month === tm) return Number(today.split("-")[2]);
+  const firstOfMonth = `${year}-${String(month).padStart(2, "0")}-01`;
+  return firstOfMonth > today ? 1 : daysInMonth(year, month);
+}
+
+export default function MonthlyView({
+  year,
+  month,
+  habits,
+  statuses,
+  onPrevMonth,
+  onNextMonth,
+  onCheckIn,
+}: Props) {
+  const today = todayISO();
+  const monthPrefix = `${year}-${String(month).padStart(2, "0")}-`;
+  const monthLength = daysInMonth(year, month);
+
+  const [logDay, setLogDay] = useState(() => defaultLogDay(year, month, today));
+  useEffect(() => {
+    setLogDay(defaultLogDay(year, month, today));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [year, month]);
+
+  const logDateISO = `${monthPrefix}${String(logDay).padStart(2, "0")}`;
+  const canLog = logDateISO <= today;
+  const canGoNext = logDay < monthLength && `${monthPrefix}${String(logDay + 1).padStart(2, "0")}` <= today;
+
+  return (
+    <View style={styles.wrap}>
+      <View style={styles.navRow}>
+        <TouchableOpacity style={styles.arrowBtn} onPress={onPrevMonth}>
+          <Text style={styles.arrowText}>‹</Text>
+        </TouchableOpacity>
+        <Text style={styles.monthLabel}>
+          {MONTH_LABELS[month - 1]} {year}
+        </Text>
+        <TouchableOpacity style={styles.arrowBtn} onPress={onNextMonth}>
+          <Text style={styles.arrowText}>›</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.logDayRow}>
+        <TouchableOpacity
+          disabled={logDay <= 1}
+          style={[styles.dayArrowBtn, logDay <= 1 && styles.dayArrowBtnDisabled]}
+          onPress={() => setLogDay((d) => d - 1)}
+        >
+          <Text style={styles.dayArrowText}>‹</Text>
+        </TouchableOpacity>
+        <Text style={styles.logDayLabel}>
+          Logging for {MONTH_ABBR[month - 1]} {logDay}
+        </Text>
+        <TouchableOpacity
+          disabled={!canGoNext}
+          style={[styles.dayArrowBtn, !canGoNext && styles.dayArrowBtnDisabled]}
+          onPress={() => setLogDay((d) => d + 1)}
+        >
+          <Text style={styles.dayArrowText}>›</Text>
+        </TouchableOpacity>
+      </View>
+
+      {habits.length === 0 ? (
+        <View style={styles.emptyState}>
+          <Text style={styles.emptyText}>
+            No monthly habits yet. Set a habit's frequency to Monthly in Edit Habit to see it here.
+          </Text>
+        </View>
+      ) : (
+        <FlatList
+          data={habits}
+          keyExtractor={(item) => item.id}
+          contentContainerStyle={styles.list}
+          renderItem={({ item }) => {
+            const target = item.frequencyCount ?? 1;
+            const count = Object.entries(statuses[item.id] ?? {}).filter(
+              ([date, status]) => status === "DONE" && date.startsWith(monthPrefix),
+            ).length;
+            const pct = Math.min(Math.round((count / target) * 100), 100);
+            const logDateStatus = statuses[item.id]?.[logDateISO] ?? "UNSET";
+
+            return (
+              <View style={styles.card}>
+                <View style={styles.cardTop}>
+                  <TouchableOpacity
+                    disabled={!canLog}
+                    style={[
+                      styles.statusIcon,
+                      logDateStatus === "DONE" && styles.statusIconDone,
+                      logDateStatus === "MISSED" && styles.statusIconMissed,
+                    ]}
+                    onPress={() =>
+                      onCheckIn(item.id, logDateISO, logDateStatus === "DONE" ? "UNSET" : "DONE")
+                    }
+                  >
+                    {logDateStatus === "DONE" && <CheckIcon size={22} />}
+                    {logDateStatus === "MISSED" && <XIcon size={22} />}
+                  </TouchableOpacity>
+                  <Text style={styles.habitName} numberOfLines={1}>
+                    {item.name}
+                  </Text>
+                  <Text style={styles.countText}>
+                    {count}/{target}
+                  </Text>
+                </View>
+                <View style={styles.barTrack}>
+                  <View style={[styles.barFill, { width: `${pct}%` as any }]} />
+                </View>
+                {canLog && (
+                  <TouchableOpacity
+                    style={[styles.missedBtn, logDateStatus === "MISSED" && styles.missedBtnActive]}
+                    onPress={() =>
+                      onCheckIn(item.id, logDateISO, logDateStatus === "MISSED" ? "UNSET" : "MISSED")
+                    }
+                  >
+                    <Text
+                      style={[
+                        styles.missedBtnText,
+                        logDateStatus === "MISSED" && styles.missedBtnTextActive,
+                      ]}
+                    >
+                      {logDateStatus === "MISSED" ? "Undo" : "Mark missed"}
+                    </Text>
+                  </TouchableOpacity>
+                )}
+              </View>
+            );
+          }}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { flex: 1 },
+  navRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 20,
+    marginBottom: 10,
+  },
+  monthLabel: {
+    fontSize: 18,
+    color: "#98eaff",
+    minWidth: 140,
+    textAlign: "center",
+  },
+  arrowBtn: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    backgroundColor: "#085331",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  arrowText: {
+    fontSize: 20,
+    color: "#98eaff",
+    lineHeight: 24,
+  },
+  logDayRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 12,
+    marginBottom: 14,
+  },
+  dayArrowBtn: {
+    width: 26,
+    height: 26,
+    borderRadius: 13,
+    backgroundColor: "#085331",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  dayArrowBtnDisabled: {
+    opacity: 0.3,
+  },
+  dayArrowText: {
+    fontSize: 15,
+    color: "#98eaff",
+    lineHeight: 18,
+  },
+  logDayLabel: {
+    fontSize: 12,
+    color: "#3a7a5a",
+    minWidth: 150,
+    textAlign: "center",
+  },
+  emptyState: {
+    marginHorizontal: 16,
+    padding: 20,
+  },
+  emptyText: {
+    fontSize: 13,
+    color: "#3a7a5a",
+    textAlign: "center",
+    lineHeight: 20,
+  },
+  list: {
+    paddingHorizontal: 16,
+    paddingBottom: 110,
+    gap: 10,
+  },
+  card: {
+    backgroundColor: "#085331",
+    borderRadius: 16,
+    padding: 16,
+    shadowColor: "#000",
+    shadowOffset: { width: -4, height: 4 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  cardTop: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    marginBottom: 10,
+  },
+  statusIcon: {
+    width: 34,
+    height: 34,
+    borderRadius: 8,
+    backgroundColor: "#000",
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 1,
+    borderColor: "rgba(152,234,255,0.1)",
+    flexShrink: 0,
+  },
+  statusIconDone: {
+    borderColor: "#009951",
+  },
+  statusIconMissed: {
+    borderColor: "#860000",
+  },
+  habitName: {
+    fontSize: 16,
+    color: "#98eaff",
+    flex: 1,
+  },
+  countText: {
+    fontSize: 14,
+    color: "#98FF9D",
+    fontWeight: "600",
+  },
+  barTrack: {
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: "rgba(0,0,0,0.4)",
+    overflow: "hidden",
+  },
+  barFill: {
+    height: "100%",
+    borderRadius: 4,
+    backgroundColor: "#009951",
+  },
+  missedBtn: {
+    alignSelf: "flex-end",
+    marginTop: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "rgba(134,0,0,0.4)",
+  },
+  missedBtnActive: {
+    backgroundColor: "rgba(134,0,0,0.2)",
+    borderColor: "#860000",
+  },
+  missedBtnText: {
+    fontSize: 11,
+    color: "rgba(255,85,85,0.5)",
+  },
+  missedBtnTextActive: {
+    color: "#ff5555",
+  },
+});

--- a/apps/mobile/src/screens/week/WeeklyView.tsx
+++ b/apps/mobile/src/screens/week/WeeklyView.tsx
@@ -1,0 +1,267 @@
+import React from "react";
+import { View, Text, FlatList, TouchableOpacity, StyleSheet } from "react-native";
+import { formatDate, todayISO } from "../../utils/dates";
+import { CheckIcon, XIcon } from "../../components/HabitIcons";
+import { DayStatus, Habit, StatusMap } from "./types";
+
+const DAY_LABELS = ["M", "Tu", "W", "Th", "F", "Sa", "Su"];
+const CELL_SIZE = 34;
+
+interface Props {
+  mondayISO: string;
+  weekDates: string[];
+  habits: Habit[];
+  statuses: StatusMap;
+  onPrevWeek: () => void;
+  onNextWeek: () => void;
+  onCellPress: (habitId: string, dayISO: string) => void;
+}
+
+export default function WeeklyView({
+  mondayISO,
+  weekDates,
+  habits,
+  statuses,
+  onPrevWeek,
+  onNextWeek,
+  onCellPress,
+}: Props) {
+  const sundayISO = weekDates[6];
+  const today = todayISO();
+  const todayColIndex = weekDates.indexOf(today);
+
+  const totalCells = habits.length * 7;
+  const doneCells = habits.reduce(
+    (sum, h) => sum + weekDates.filter((d) => statuses[h.id]?.[d] === "DONE").length,
+    0,
+  );
+  const weekPct = totalCells > 0 ? Math.round((doneCells / totalCells) * 100) : 0;
+
+  return (
+    <View style={styles.wrap}>
+      <View style={styles.dateCard}>
+        <View style={styles.dateRow}>
+          <View style={styles.datePill}>
+            <Text style={styles.datePillText}>{formatDate(mondayISO)}</Text>
+          </View>
+          <TouchableOpacity style={styles.arrowBtn} onPress={onPrevWeek}>
+            <Text style={styles.arrowText}>‹</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.arrowBtn} onPress={onNextWeek}>
+            <Text style={styles.arrowText}>›</Text>
+          </TouchableOpacity>
+          <View style={styles.datePill}>
+            <Text style={styles.datePillText}>{formatDate(sundayISO)}</Text>
+          </View>
+          {habits.length > 0 && (
+            <View style={styles.pctPill}>
+              <Text style={styles.pctPillText}>{weekPct}%</Text>
+            </View>
+          )}
+        </View>
+
+        {/* Day headers — aligned to cells below */}
+        <View style={styles.dayHeaderRow}>
+          <View style={styles.habitNameCol} />
+          {DAY_LABELS.map((label, i) => (
+            <View key={i} style={styles.cellSlot}>
+              <Text style={[styles.dayLabel, i === todayColIndex && styles.dayLabelToday]}>
+                {label}
+              </Text>
+            </View>
+          ))}
+        </View>
+      </View>
+
+      {habits.length === 0 ? (
+        <View style={styles.emptyState}>
+          <Text style={styles.emptyText}>
+            No weekly habits yet. Set a habit's frequency to Weekly in Edit Habit to see it here.
+          </Text>
+        </View>
+      ) : (
+        <FlatList
+          data={habits}
+          keyExtractor={(item) => item.id}
+          contentContainerStyle={styles.list}
+          renderItem={({ item }) => {
+            const target = item.frequencyCount ?? 1;
+            const count = weekDates.filter((d) => statuses[item.id]?.[d] === "DONE").length;
+
+            return (
+              <View style={styles.habitCard}>
+                <View style={styles.habitNameCol}>
+                  <Text style={styles.habitName} numberOfLines={1}>
+                    {item.name}
+                  </Text>
+                  <Text style={styles.habitTarget}>
+                    {count}/{target}
+                  </Text>
+                </View>
+                <View style={styles.cellRow}>
+                  {weekDates.map((dayISO, i) => {
+                    const status: DayStatus = statuses[item.id]?.[dayISO] ?? "UNSET";
+                    const isToday = i === todayColIndex;
+
+                    return (
+                      <TouchableOpacity
+                        key={dayISO}
+                        style={[styles.cell, isToday && styles.cellToday]}
+                        onPress={() => onCellPress(item.id, dayISO)}
+                      >
+                        {status === "DONE" && <CheckIcon size={30} />}
+                        {status === "MISSED" && <XIcon size={30} />}
+                      </TouchableOpacity>
+                    );
+                  })}
+                </View>
+              </View>
+            );
+          }}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { flex: 1 },
+  dateCard: {
+    backgroundColor: "#085331",
+    borderRadius: 16,
+    marginHorizontal: 16,
+    marginBottom: 12,
+    paddingTop: 10,
+    shadowColor: "#000",
+    shadowOffset: { width: -4, height: 4 },
+    shadowOpacity: 0.4,
+    shadowRadius: 12,
+    elevation: 6,
+  },
+  dateRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 10,
+    gap: 8,
+    marginBottom: 8,
+  },
+  datePill: {
+    flex: 1,
+    backgroundColor: "#000",
+    borderRadius: 10,
+    paddingVertical: 8,
+    alignItems: "center",
+  },
+  datePillText: {
+    fontSize: 11,
+    color: "#98eaff",
+  },
+  pctPill: {
+    backgroundColor: "rgba(0,153,81,0.25)",
+    borderRadius: 10,
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    borderWidth: 1,
+    borderColor: "#009951",
+  },
+  pctPillText: {
+    fontSize: 12,
+    color: "#98FF9D",
+    fontWeight: "600",
+  },
+  arrowBtn: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    backgroundColor: "#000",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+  },
+  arrowText: {
+    fontSize: 20,
+    color: "#98eaff",
+    lineHeight: 24,
+  },
+  dayHeaderRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 12,
+    paddingBottom: 10,
+  },
+  habitNameCol: {
+    width: 80,
+    flexShrink: 0,
+  },
+  cellSlot: {
+    width: CELL_SIZE,
+    alignItems: "center",
+    marginHorizontal: 2,
+  },
+  dayLabel: {
+    fontSize: 11,
+    color: "#98eaff",
+    fontWeight: "400",
+  },
+  dayLabelToday: {
+    color: "#98FF9D",
+    fontWeight: "600",
+  },
+  list: {
+    paddingHorizontal: 16,
+    paddingBottom: 110,
+    gap: 8,
+  },
+  habitCard: {
+    backgroundColor: "#085331",
+    borderRadius: 14,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    flexDirection: "row",
+    alignItems: "center",
+    shadowColor: "#000",
+    shadowOffset: { width: -4, height: 4 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  habitName: {
+    fontSize: 13,
+    color: "#98eaff",
+    paddingRight: 4,
+  },
+  habitTarget: {
+    fontSize: 11,
+    color: "#3a7a5a",
+    marginTop: 2,
+  },
+  emptyState: {
+    marginHorizontal: 16,
+    padding: 20,
+  },
+  emptyText: {
+    fontSize: 13,
+    color: "#3a7a5a",
+    textAlign: "center",
+    lineHeight: 20,
+  },
+  cellRow: {
+    flexDirection: "row",
+    flex: 1,
+    justifyContent: "space-between",
+  },
+  cell: {
+    width: CELL_SIZE,
+    height: CELL_SIZE,
+    borderRadius: 8,
+    backgroundColor: "#000",
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 1,
+    borderColor: "rgba(152,234,255,0.08)",
+  },
+  cellToday: {
+    borderWidth: 1.5,
+    borderColor: "rgba(152,234,255,0.45)",
+  },
+});

--- a/apps/mobile/src/screens/week/YearlyView.tsx
+++ b/apps/mobile/src/screens/week/YearlyView.tsx
@@ -1,0 +1,294 @@
+import React, { useState, useEffect } from "react";
+import { View, Text, FlatList, TouchableOpacity, StyleSheet } from "react-native";
+import { MONTH_ABBR, addDays, todayISO } from "../../utils/dates";
+import { CheckIcon, XIcon } from "../../components/HabitIcons";
+import { DayStatus, Habit, StatusMap } from "./types";
+
+interface Props {
+  year: number;
+  habits: Habit[];
+  statuses: StatusMap;
+  onPrevYear: () => void;
+  onNextYear: () => void;
+  onCheckIn: (habitId: string, dateISO: string, next: DayStatus) => void;
+}
+
+// Defaults the log cursor to today (current year), or Dec 31 of a past year —
+// there's no meaningful "today" to default to once you're browsing history.
+function defaultLogDate(year: number, today: string): string {
+  const todayYear = Number(today.split("-")[0]);
+  if (year === todayYear) return today;
+  const dec31 = `${year}-12-31`;
+  return dec31 > today ? `${year}-01-01` : dec31;
+}
+
+function formatShort(dateISO: string): string {
+  const [, m, d] = dateISO.split("-").map(Number);
+  return `${MONTH_ABBR[m - 1]} ${d}`;
+}
+
+export default function YearlyView({ year, habits, statuses, onPrevYear, onNextYear, onCheckIn }: Props) {
+  const today = todayISO();
+  const yearPrefix = `${year}-`;
+  const jan1 = `${year}-01-01`;
+  const dec31 = `${year}-12-31`;
+
+  const [logDateISO, setLogDateISO] = useState(() => defaultLogDate(year, today));
+  useEffect(() => {
+    setLogDateISO(defaultLogDate(year, today));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [year]);
+
+  const canLog = logDateISO <= today;
+  const canGoPrev = logDateISO > jan1;
+  const canGoNext = logDateISO < dec31 && addDays(logDateISO, 1) <= today;
+
+  return (
+    <View style={styles.wrap}>
+      <View style={styles.navRow}>
+        <TouchableOpacity style={styles.arrowBtn} onPress={onPrevYear}>
+          <Text style={styles.arrowText}>‹</Text>
+        </TouchableOpacity>
+        <Text style={styles.yearLabel}>{year}</Text>
+        <TouchableOpacity style={styles.arrowBtn} onPress={onNextYear}>
+          <Text style={styles.arrowText}>›</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.logDayRow}>
+        <TouchableOpacity
+          disabled={!canGoPrev}
+          style={[styles.dayArrowBtn, !canGoPrev && styles.dayArrowBtnDisabled]}
+          onPress={() => setLogDateISO((d) => addDays(d, -1))}
+        >
+          <Text style={styles.dayArrowText}>‹</Text>
+        </TouchableOpacity>
+        <Text style={styles.logDayLabel}>Logging for {formatShort(logDateISO)}</Text>
+        <TouchableOpacity
+          disabled={!canGoNext}
+          style={[styles.dayArrowBtn, !canGoNext && styles.dayArrowBtnDisabled]}
+          onPress={() => setLogDateISO((d) => addDays(d, 1))}
+        >
+          <Text style={styles.dayArrowText}>›</Text>
+        </TouchableOpacity>
+      </View>
+
+      {habits.length === 0 ? (
+        <View style={styles.emptyState}>
+          <Text style={styles.emptyText}>
+            No yearly habits yet. Set a habit's frequency to Yearly in Edit Habit to see it here.
+          </Text>
+        </View>
+      ) : (
+        <FlatList
+          data={habits}
+          keyExtractor={(item) => item.id}
+          contentContainerStyle={styles.list}
+          renderItem={({ item }) => {
+            const target = item.frequencyCount ?? 1;
+            const count = Object.entries(statuses[item.id] ?? {}).filter(
+              ([date, status]) => status === "DONE" && date.startsWith(yearPrefix),
+            ).length;
+            const pct = Math.min(Math.round((count / target) * 100), 100);
+            const logDateStatus = statuses[item.id]?.[logDateISO] ?? "UNSET";
+
+            return (
+              <View style={styles.card}>
+                <View style={styles.cardTop}>
+                  <TouchableOpacity
+                    disabled={!canLog}
+                    style={[
+                      styles.statusIcon,
+                      logDateStatus === "DONE" && styles.statusIconDone,
+                      logDateStatus === "MISSED" && styles.statusIconMissed,
+                    ]}
+                    onPress={() =>
+                      onCheckIn(item.id, logDateISO, logDateStatus === "DONE" ? "UNSET" : "DONE")
+                    }
+                  >
+                    {logDateStatus === "DONE" && <CheckIcon size={22} />}
+                    {logDateStatus === "MISSED" && <XIcon size={22} />}
+                  </TouchableOpacity>
+                  <Text style={styles.habitName} numberOfLines={1}>
+                    {item.name}
+                  </Text>
+                  <Text style={styles.countText}>
+                    {count}/{target}
+                  </Text>
+                </View>
+                <View style={styles.barTrack}>
+                  <View style={[styles.barFill, { width: `${pct}%` as any }]} />
+                </View>
+                {canLog && (
+                  <TouchableOpacity
+                    style={[styles.missedBtn, logDateStatus === "MISSED" && styles.missedBtnActive]}
+                    onPress={() =>
+                      onCheckIn(item.id, logDateISO, logDateStatus === "MISSED" ? "UNSET" : "MISSED")
+                    }
+                  >
+                    <Text
+                      style={[
+                        styles.missedBtnText,
+                        logDateStatus === "MISSED" && styles.missedBtnTextActive,
+                      ]}
+                    >
+                      {logDateStatus === "MISSED" ? "Undo" : "Mark missed"}
+                    </Text>
+                  </TouchableOpacity>
+                )}
+              </View>
+            );
+          }}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { flex: 1 },
+  navRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 20,
+    marginBottom: 10,
+  },
+  yearLabel: {
+    fontSize: 20,
+    color: "#98eaff",
+    minWidth: 60,
+    textAlign: "center",
+  },
+  arrowBtn: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    backgroundColor: "#085331",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  arrowText: {
+    fontSize: 20,
+    color: "#98eaff",
+    lineHeight: 24,
+  },
+  logDayRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 12,
+    marginBottom: 14,
+  },
+  dayArrowBtn: {
+    width: 26,
+    height: 26,
+    borderRadius: 13,
+    backgroundColor: "#085331",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  dayArrowBtnDisabled: {
+    opacity: 0.3,
+  },
+  dayArrowText: {
+    fontSize: 15,
+    color: "#98eaff",
+    lineHeight: 18,
+  },
+  logDayLabel: {
+    fontSize: 12,
+    color: "#3a7a5a",
+    minWidth: 150,
+    textAlign: "center",
+  },
+  emptyState: {
+    marginHorizontal: 16,
+    padding: 20,
+  },
+  emptyText: {
+    fontSize: 13,
+    color: "#3a7a5a",
+    textAlign: "center",
+    lineHeight: 20,
+  },
+  list: {
+    paddingHorizontal: 16,
+    paddingBottom: 110,
+    gap: 10,
+  },
+  card: {
+    backgroundColor: "#085331",
+    borderRadius: 16,
+    padding: 16,
+    shadowColor: "#000",
+    shadowOffset: { width: -4, height: 4 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  cardTop: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    marginBottom: 10,
+  },
+  statusIcon: {
+    width: 34,
+    height: 34,
+    borderRadius: 8,
+    backgroundColor: "#000",
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 1,
+    borderColor: "rgba(152,234,255,0.1)",
+    flexShrink: 0,
+  },
+  statusIconDone: {
+    borderColor: "#009951",
+  },
+  statusIconMissed: {
+    borderColor: "#860000",
+  },
+  habitName: {
+    fontSize: 16,
+    color: "#98eaff",
+    flex: 1,
+  },
+  countText: {
+    fontSize: 14,
+    color: "#98FF9D",
+    fontWeight: "600",
+  },
+  barTrack: {
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: "rgba(0,0,0,0.4)",
+    overflow: "hidden",
+  },
+  barFill: {
+    height: "100%",
+    borderRadius: 4,
+    backgroundColor: "#009951",
+  },
+  missedBtn: {
+    alignSelf: "flex-end",
+    marginTop: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "rgba(134,0,0,0.4)",
+  },
+  missedBtnActive: {
+    backgroundColor: "rgba(134,0,0,0.2)",
+    borderColor: "#860000",
+  },
+  missedBtnText: {
+    fontSize: 11,
+    color: "rgba(255,85,85,0.5)",
+  },
+  missedBtnTextActive: {
+    color: "#ff5555",
+  },
+});

--- a/apps/mobile/src/screens/week/types.ts
+++ b/apps/mobile/src/screens/week/types.ts
@@ -1,0 +1,21 @@
+export type DayStatus = "UNSET" | "DONE" | "MISSED";
+
+// statuses[habitId][dayISO] = DayStatus — full history, shared across all 4 views
+export type StatusMap = Record<string, Record<string, DayStatus>>;
+
+export type ViewMode = "daily" | "weekly" | "monthly" | "yearly";
+
+export interface Habit {
+  id: string;
+  name: string;
+  frequencyType?: string;
+  frequencyCount?: number;
+  [key: string]: any;
+}
+
+// One row per completion — only used by DAILY habits with frequencyCount > 1
+export interface HabitLogEntry {
+  id: string;
+  habitId: string;
+  loggedAt: string; // ISO datetime, hour:minute precision
+}

--- a/apps/mobile/src/utils/dates.ts
+++ b/apps/mobile/src/utils/dates.ts
@@ -11,6 +11,22 @@ export function todayISO(): string {
   return toLocalISO(new Date());
 }
 
+// Local calendar date of a full ISO datetime string (e.g. a HabitLog's loggedAt) —
+// same UTC-avoidance reasoning as the rest of this file.
+export function localDateOf(isoDateTime: string): string {
+  return toLocalISO(new Date(isoDateTime));
+}
+
+// h:mm AM/PM in local time, for displaying a log entry's timestamp
+export function formatTime(isoDateTime: string): string {
+  const d = new Date(isoDateTime);
+  let hours = d.getHours();
+  const minutes = String(d.getMinutes()).padStart(2, "0");
+  const period = hours >= 12 ? "PM" : "AM";
+  hours = hours % 12 || 12;
+  return `${hours}:${minutes} ${period}`;
+}
+
 export function getMondayISO(from: Date = new Date()): string {
   const d = new Date(from);
   const day = d.getDay(); // local day: 0=Sun, 1=Mon, ...
@@ -35,4 +51,41 @@ export function buildWeekDates(mondayISO: string): string[] {
 export function formatDate(isoDate: string): string {
   const [year, month, day] = isoDate.split("-");
   return `${month}/${day}/${year.slice(2)}`;
+}
+
+export const MONTH_LABELS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+export const MONTH_ABBR = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+// month is 1-indexed (1 = January), matching Prisma/JS date conventions used elsewhere
+export function daysInMonth(year: number, month: number): number {
+  return new Date(year, month, 0).getDate();
+}
+
+export function getMonthDates(year: number, month: number): string[] {
+  const n = daysInMonth(year, month);
+  return Array.from(
+    { length: n },
+    (_, i) => `${year}-${String(month).padStart(2, "0")}-${String(i + 1).padStart(2, "0")}`,
+  );
+}
+
+// Monday-start calendar grid for a month, padded with nulls so every row has 7 cells
+export function getCalendarGrid(year: number, month: number): (string | null)[] {
+  const dates = getMonthDates(year, month);
+  const firstDow = new Date(dates[0] + "T00:00:00").getDay(); // 0=Sun..6=Sat
+  const leadingBlanks = firstDow === 0 ? 6 : firstDow - 1;
+  const grid: (string | null)[] = Array(leadingBlanks).fill(null).concat(dates);
+  while (grid.length % 7 !== 0) grid.push(null);
+  return grid;
+}
+
+export function addMonths(year: number, month: number, n: number): { year: number; month: number } {
+  const total = year * 12 + (month - 1) + n;
+  return { year: Math.floor(total / 12), month: (((total % 12) + 12) % 12) + 1 };
 }

--- a/apps/mobile/src/utils/version.ts
+++ b/apps/mobile/src/utils/version.ts
@@ -1,0 +1,13 @@
+// Compares dotted version strings like "1.2.0" segment by segment
+export function isNewerVersion(latest: string, current: string): boolean {
+  const l = latest.split(".").map(Number);
+  const c = current.split(".").map(Number);
+
+  for (let i = 0; i < Math.max(l.length, c.length); i++) {
+    const a = l[i] ?? 0;
+    const b = c[i] ?? 0;
+    if (a > b) return true;
+    if (a < b) return false;
+  }
+  return false;
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,28 @@ When cutting a release, move `[Unreleased]` items into a new dated version secti
 
 ## [Unreleased]
 
+### Mobile
+
+#### Added
+- **Calendar screen** (formerly "Weekly") — 4 scoped views (Day / Week / Month / Year), each showing only habits whose `frequencyType` matches that scope, so a "gym 5x/week" habit lives in the Week view and a "vacation 2x/year" habit lives in the Year view, not every view
+- **Multi-completion habit logging** — DAILY habits with `frequencyCount > 1` (e.g. "eat 2x/day") can log multiple timestamped completions per day via the new `HabitLog` data; Daily view shows a progress bar, each logged time, and a way to undo a specific entry
+- **OTA auto-update** — checks for a JS-only update on every launch and applies it immediately instead of waiting for the next cold start
+- **Native update notifier** — modal (matching the delete-habit confirmation style) prompts the user to update via TestFlight when a new native build exists, since Apple never allows silent native updates
+- **Dark keyboard** — `keyboardAppearance="dark"` on every text input (Login, Register, Create/Edit Habit)
+
+#### Changed
+- "Weekly" tab renamed to "Calendar"
+- Week view now shows a `count/target` badge per habit row (e.g. "3/5") instead of just cell icons
+
+#### Fixed
+- `useFocusEffect` → `useIsFocused` on Week and Profile screens — data no longer stays blank when the token loads from SecureStore after an app restart
+
+### Backend
+
+#### Added
+- `HabitLog` model + `GET/POST /habit-logs`, `DELETE /habit-logs/:id` — supports multi-completion habits
+- `GET /app-version` — lets the mobile app tell OTA-updatable JS changes apart from native rebuilds
+
 ---
 
 ## [1.1.0] — 2026-07-04

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,10 +24,10 @@ This repo is set up like a small Jira, but native to GitHub:
 
 No date-based milestones — this project moves at a weekends-whenever pace, so the board is organized by status and phase, not deadlines.
 
-## Current state of the app (as of this doc)
+## Current state of the app (as of 2026-07-12)
 
-- **Web** (React + Vite): full habit CRUD + daily check-in grid. Working.
-- **Mobile** (React Native): auth works, habits are read-only. This is the active gap.
-- **Backend** (Node/Express): shared by both clients, single database. Auth + habit CRUD endpoints exist and are used by web.
+- **Web** (React + Vite): full habit CRUD + daily check-in grid. Working, not actively developed.
+- **Mobile** (React Native / Expo): primary active development area. Full habit CRUD, frequency rules (DAILY/WEEKLY/MONTHLY/YEARLY + count), real streaks, Calendar screen with 4 scoped views, multi-completion logging, OTA auto-update. See [`mobile/requirements.md`](./mobile/requirements.md) for the full status table.
+- **Backend** (Node/Express): shared by both clients, Postgres (NeonDB) in production. Deployed on Render.
 
-Active priority: **Mobile Habit Parity** — bring mobile up to web's functionality.
+Active priority: mobile feature depth (Calendar redesign, multi-completion habits, update mechanism) — see `docs/CHANGELOG.md` `[Unreleased]` for what's shipped but not yet released.

--- a/docs/mobile/requirements.md
+++ b/docs/mobile/requirements.md
@@ -19,11 +19,15 @@ Stack: React Native
 | Custom tab bar | ✅ Done (floating, Feather icons) |
 | SVG check/X icons | ✅ Done (react-native-svg) |
 | Loading states (login/register) | ❌ Not built |
-| Real streaks | ❌ Not built (mock on Profile) |
+| Real streaks | ✅ Working (frequency-aware, `utils/streak.ts`) |
 | Reminders / push notifications | ❌ Not built |
 | Progress analytics | ❌ Partial (Profile shows basic stats) |
-| Habit rules / frequency | ❌ Not built |
-| Individual habit detail view | ❌ Not built |
+| Habit rules / frequency | ✅ Working (DAILY/WEEKLY/MONTHLY/YEARLY + count) |
+| Individual habit detail view | ✅ Done (HabitDetailScreen — 30-day dot grid, stats) |
+| Multi-completion logging (e.g. "eat 2x/day") | ✅ Done (`HabitLog`, Daily view) |
+| Calendar screen (Day/Week/Month/Year, scoped by frequency) | ✅ Done |
+| OTA auto-update + native update notifier | ✅ Done |
+| Home screen redesign (swipe-to-delete, +/- modes) | ✅ Done |
 | Home → Dashboard restructure | ❌ Not built |
 | Profile → Account settings | ❌ Not built |
 | Animations | ❌ Not built |
@@ -40,6 +44,10 @@ Completed as part of Mobile Habit Parity epic. All mobile API calls map to exist
 | Delete habit | `DELETE /habits/:id` | — | ✅ |
 | Get habit days | `GET /habit-days` | — | ✅ |
 | Save check-in | `PUT /habit-days` | `{ habitId, date, status }` | ✅ |
+| Get habit logs | `GET /habit-logs` | — | ✅ |
+| Log a completion | `POST /habit-logs` | `{ habitId, loggedAt? }` | ✅ |
+| Undo a completion | `DELETE /habit-logs/:id` | — | ✅ |
+| App version check | `GET /app-version` | — | ✅ |
 
 **No duplicated validation logic on mobile.** The only client-side guard is blocking Save when the name field is empty — this is a UX guard, not business logic. All real validation (ownership, empty name, status enum) lives on the backend.
 

--- a/packages/db/prisma/migrations/20260712040503_add_habit_log/migration.sql
+++ b/packages/db/prisma/migrations/20260712040503_add_habit_log/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "HabitLog" (
+    "id" TEXT NOT NULL,
+    "habitId" TEXT NOT NULL,
+    "loggedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "HabitLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "HabitLog_habitId_loggedAt_idx" ON "HabitLog"("habitId", "loggedAt");
+
+-- AddForeignKey
+ALTER TABLE "HabitLog" ADD CONSTRAINT "HabitLog_habitId_fkey" FOREIGN KEY ("habitId") REFERENCES "Habit"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -34,6 +34,7 @@ model Habit {
 
   user User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   days HabitDay[]
+  logs HabitLog[]
 }
 
 model HabitDay {
@@ -45,6 +46,18 @@ model HabitDay {
 
   @@id([habitId, date])     // one record per habit per day
   @@index([date])
+}
+
+// One row per completion — only used by habits that need more than one check-in
+// per day (e.g. "eat 2x/day"). Habits with frequencyCount 1 keep using HabitDay.
+model HabitLog {
+  id       String   @id @default(cuid())
+  habitId  String
+  loggedAt DateTime // hour:minute precision, seconds don't matter
+
+  habit Habit @relation(fields: [habitId], references: [id], onDelete: Cascade)
+
+  @@index([habitId, loggedAt])
 }
 
 enum DayStatus {


### PR DESCRIPTION
## Summary
- Home screen redesign: swipe-to-delete, +/- modes, Missed button, skeleton add card (prior work on this branch)
- `useFocusEffect` → `useIsFocused` fix so Home/Week/Profile data loads correctly after an app restart
- **Calendar screen** (renamed from "Weekly"): 4 views (Day/Week/Month/Year) that each filter habits by `frequencyType`, so a habit only shows up in the view matching its actual rule (e.g. a "gym 5x/week" habit lives in the Week view, not every view)
- **Multi-completion habit logging**: new `HabitLog` model lets a habit with `frequencyCount > 1` in a single day (e.g. "eat 2x/day") log multiple timestamped completions, with a progress bar + per-entry undo in Daily view
- **Update mechanism**: silent OTA reload on launch for JS-only changes, plus a TestFlight-update prompt (matching the delete-habit modal style) when a native rebuild is available
- Dark keyboard (`keyboardAppearance="dark"`) on every text input
- `GET /app-version` endpoint for the update mechanism above
- Docs: CHANGELOG `[Unreleased]` entry, refreshed mobile requirements status table and docs README (both were stale)

## Database
- `HabitLog` migration already applied to **both** dev and prod NeonDB branches — purely additive (new table + index + FK), no existing tables touched, no downtime. Prod DB is ahead of this code; that's the safe order.

## Test plan
- [x] Calendar screen: verify each of the 4 views only shows habits with the matching frequency type
- [x] Log a multi-completion habit (frequencyCount > 1) in Daily view — add/remove entries, confirm progress bar and count update
- [ ] Confirm app data loads correctly after a full app restart (Home, Week, Profile)
- [x] Confirm keyboard appears dark on Login, Register, Create Habit, Edit Habit
- [x] Ship as an EAS Update (JS-only, no new native deps) once merged