### PR TITLE
Rotating refresh tokens + redirect to Login on expired session

### DIFF
--- a/apps/api/src/routes/auth.routes.ts
+++ b/apps/api/src/routes/auth.routes.ts
@@ -2,8 +2,25 @@ import { Router } from "express";
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import { prisma } from "../../../../packages/db/src/prisma";
+import { generateRefreshToken, hashRefreshToken, refreshTokenExpiry } from "../utils/tokens";
 
 const router = Router();
+
+// Access token stays short-lived (1h) — the refresh token is what actually
+// keeps a user signed in. Every successful refresh rotates both: the old
+// refresh token row is deleted and a new one issued with expiresAt pushed
+// another 30 days out, so an active user never re-logs-in, but 30 days of
+// inactivity (or a stolen token going unused) forces a real login.
+async function issueTokens(userId: string, email: string) {
+  const token = jwt.sign({ userId, email }, process.env.JWT_SECRET!, { expiresIn: "1h" });
+
+  const refreshToken = generateRefreshToken();
+  await prisma.refreshToken.create({
+    data: { userId, tokenHash: hashRefreshToken(refreshToken), expiresAt: refreshTokenExpiry() },
+  });
+
+  return { token, refreshToken };
+}
 
 // POST /auth/register — create a new account and return a JWT
 router.post("/register", async (req, res) => {
@@ -22,13 +39,8 @@ router.post("/register", async (req, res) => {
   const hashed = await bcrypt.hash(password, 10);
   const user = await prisma.user.create({ data: { email, password: hashed } });
 
-  const token = jwt.sign(
-    { userId: user.id, email: user.email },
-    process.env.JWT_SECRET!,
-    { expiresIn: "1h" } // token expires after 1 hour — frontend must re-login after expiry
-  );
-
-  res.status(201).json({ token });
+  const { token, refreshToken } = await issueTokens(user.id, user.email);
+  res.status(201).json({ token, refreshToken });
 });
 
 // POST /auth/login — verify credentials and return a fresh JWT
@@ -52,13 +64,47 @@ router.post("/login", async (req, res) => {
     return res.status(401).json({ error: "Invalid credentials" });
   }
 
-  const token = jwt.sign(
-    { userId: user.id, email: user.email },
-    process.env.JWT_SECRET!,
-    { expiresIn: "1h" }
-  );
+  const { token, refreshToken } = await issueTokens(user.id, user.email);
+  res.json({ token, refreshToken });
+});
 
-  res.json({ token });
+// POST /auth/refresh — trade a valid, unexpired refresh token for a new
+// access token, rotating the refresh token in the same call
+router.post("/refresh", async (req, res) => {
+  const { refreshToken } = req.body;
+
+  if (!refreshToken || typeof refreshToken !== "string") {
+    return res.status(400).json({ error: "refreshToken is required" });
+  }
+
+  const tokenHash = hashRefreshToken(refreshToken);
+  const stored = await prisma.refreshToken.findUnique({
+    where: { tokenHash },
+    include: { user: true },
+  });
+
+  if (!stored || stored.expiresAt < new Date()) {
+    return res.status(401).json({ error: "Refresh token expired or invalid" });
+  }
+
+  // Rotate: delete the used token before issuing a new one, so a stolen
+  // refresh token can't be replayed after the legitimate client uses it
+  await prisma.refreshToken.delete({ where: { id: stored.id } });
+
+  const tokens = await issueTokens(stored.user.id, stored.user.email);
+  res.json(tokens);
+});
+
+// POST /auth/logout — best-effort revoke so a stolen refresh token stops
+// working immediately instead of staying valid for its remaining 30 days
+router.post("/logout", async (req, res) => {
+  const { refreshToken } = req.body;
+
+  if (refreshToken && typeof refreshToken === "string") {
+    await prisma.refreshToken.deleteMany({ where: { tokenHash: hashRefreshToken(refreshToken) } });
+  }
+
+  res.status(204).send();
 });
 
 export default router;

--- a/apps/api/src/utils/tokens.ts
+++ b/apps/api/src/utils/tokens.ts
@@ -1,0 +1,19 @@
+import crypto from "crypto";
+
+export const REFRESH_TOKEN_TTL_DAYS = 30;
+
+// Raw token handed to the client — high-entropy random bytes, not a JWT.
+export function generateRefreshToken(): string {
+  return crypto.randomBytes(40).toString("hex");
+}
+
+// Only the hash is stored, so a leaked DB doesn't hand out usable tokens.
+// SHA-256 (not bcrypt) is fine here since the input is already high-entropy,
+// unlike a user-chosen password.
+export function hashRefreshToken(token: string): string {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+export function refreshTokenExpiry(): Date {
+  return new Date(Date.now() + REFRESH_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000);
+}

--- a/apps/mobile/src/context/AuthContext.tsx
+++ b/apps/mobile/src/context/AuthContext.tsx
@@ -1,10 +1,19 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useContext, useState, useEffect, useRef } from 'react';
 import * as SecureStore from 'expo-secure-store';
+import { API_URL } from '../api/client';
+
+type Tokens = { token: string; refreshToken: string };
 
 type AuthContextType = {
     token: string | null;
-    login: (token: string) => Promise<void>;
+    login: (token: string, refreshToken: string) => Promise<void>;
     logout: () => Promise<void>;
+    // Drop-in replacement for fetch on authenticated routes: attaches the
+    // Authorization header, and on a 401 transparently refreshes the access
+    // token once and retries before giving up. If the refresh token itself
+    // is invalid/expired, logs out — which flips RootNavigator back to the
+    // AuthStack, so the user lands on Login instead of a silently broken screen.
+    authorizedFetch: (url: string, options?: RequestInit) => Promise<Response>;
 };
 
 const AuthContext = createContext<AuthContextType | null>(null);
@@ -12,22 +21,120 @@ const AuthContext = createContext<AuthContextType | null>(null);
 export function AuthProvider({ children }: {children: React.ReactNode}) {
     const [token, setToken] = useState<string | null>(null);
 
+    // Refs mirror state for use inside authorizedFetch/refresh logic, which
+    // can run mid-render-cycle (e.g. a screen's Promise.all firing several
+    // authorizedFetch calls at once) and needs the latest values synchronously.
+    const tokenRef = useRef<string | null>(null);
+    const refreshTokenRef = useRef<string | null>(null);
+    // Dedupes concurrent 401s: without this, N parallel requests failing at
+    // once would each call /auth/refresh, and since refresh tokens rotate
+    // (single-use), only the first would succeed — the rest would see their
+    // now-stale refresh token rejected and wrongly force a logout.
+    const refreshPromiseRef = useRef<Promise<Tokens | null> | null>(null);
+
     useEffect(() => {
-        SecureStore.getItemAsync('token').then(setToken);
+        Promise.all([
+            SecureStore.getItemAsync('token'),
+            SecureStore.getItemAsync('refreshToken'),
+        ]).then(([storedToken, storedRefreshToken]) => {
+            tokenRef.current = storedToken;
+            refreshTokenRef.current = storedRefreshToken;
+            setToken(storedToken);
+        });
     }, []);
 
-    const login = async (newToken: string) => {
-        await SecureStore.setItemAsync('token', newToken);
+    async function persistTokens(newToken: string, newRefreshToken: string) {
+        tokenRef.current = newToken;
+        refreshTokenRef.current = newRefreshToken;
+        await Promise.all([
+            SecureStore.setItemAsync('token', newToken),
+            SecureStore.setItemAsync('refreshToken', newRefreshToken),
+        ]);
         setToken(newToken);
-    };
-    
-    const logout = async () => {
-        await SecureStore.deleteItemAsync('token');
-        setToken(null);
+    }
+
+    const login = async (newToken: string, newRefreshToken: string) => {
+        await persistTokens(newToken, newRefreshToken);
     };
 
+    const logout = async () => {
+        const refreshToken = refreshTokenRef.current;
+        tokenRef.current = null;
+        refreshTokenRef.current = null;
+        await Promise.all([
+            SecureStore.deleteItemAsync('token'),
+            SecureStore.deleteItemAsync('refreshToken'),
+        ]);
+        setToken(null);
+
+        // Best-effort server-side revoke so a stolen refresh token can't
+        // keep working for its remaining 30 days after an explicit logout.
+        if (refreshToken) {
+            try {
+                await fetch(`${API_URL}/auth/logout`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ refreshToken }),
+                });
+            } catch {
+                // Offline or server down — local logout already happened, which
+                // is what actually matters for the user.
+            }
+        }
+    };
+
+    async function refreshTokens(): Promise<Tokens | null> {
+        if (refreshPromiseRef.current) return refreshPromiseRef.current;
+
+        const promise = (async (): Promise<Tokens | null> => {
+            const currentRefreshToken = refreshTokenRef.current;
+            if (!currentRefreshToken) return null;
+
+            try {
+                const res = await fetch(`${API_URL}/auth/refresh`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ refreshToken: currentRefreshToken }),
+                });
+                if (!res.ok) return null;
+
+                const data = await res.json();
+                await persistTokens(data.token, data.refreshToken);
+                return data;
+            } catch {
+                return null;
+            }
+        })();
+
+        refreshPromiseRef.current = promise;
+        try {
+            return await promise;
+        } finally {
+            refreshPromiseRef.current = null;
+        }
+    }
+
+    async function authorizedFetch(url: string, options: RequestInit = {}): Promise<Response> {
+        const res = await fetch(url, {
+            ...options,
+            headers: { ...options.headers, Authorization: `Bearer ${tokenRef.current}` },
+        });
+        if (res.status !== 401) return res;
+
+        const refreshed = await refreshTokens();
+        if (!refreshed) {
+            await logout();
+            return res;
+        }
+
+        return fetch(url, {
+            ...options,
+            headers: { ...options.headers, Authorization: `Bearer ${refreshed.token}` },
+        });
+    }
+
     return (
-        <AuthContext.Provider value={{ token, login, logout }}>
+        <AuthContext.Provider value={{ token, login, logout, authorizedFetch }}>
             {children}
         </AuthContext.Provider>
     );

--- a/apps/mobile/src/screens/CreateHabitScreen.tsx
+++ b/apps/mobile/src/screens/CreateHabitScreen.tsx
@@ -33,7 +33,7 @@ function countRange(type: FrequencyType): number[] {
 }
 
 export default function CreateHabitScreen({ navigation }: Props) {
-  const { token } = useAuth();
+  const { authorizedFetch } = useAuth();
   const [name, setName] = useState("");
   const [notes, setNotes] = useState("");
   const [freqType, setFreqType] = useState<FrequencyType>("DAILY");
@@ -44,12 +44,9 @@ export default function CreateHabitScreen({ navigation }: Props) {
     if (!name.trim()) return;
     setLoading(true);
     try {
-      const res = await fetch(`${API_URL}/habits`, {
+      const res = await authorizedFetch(`${API_URL}/habits`, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name: name.trim(), notes: notes.trim() || undefined, frequencyType: freqType, frequencyCount: freqCount }),
       });
       if (!res.ok) {

--- a/apps/mobile/src/screens/EditHabitScreen.tsx
+++ b/apps/mobile/src/screens/EditHabitScreen.tsx
@@ -38,7 +38,7 @@ function countLabel(type: FrequencyType, count: number): string {
 }
 
 export default function EditHabitScreen({ navigation, route }: Props) {
-  const { token } = useAuth();
+  const { authorizedFetch } = useAuth();
   const { id, name: initialName, notes: initialNotes, frequency: initialFreq } = route.params;
   const [name, setName] = useState(initialName);
   const [notes, setNotes] = useState(initialNotes ?? "");
@@ -55,12 +55,9 @@ export default function EditHabitScreen({ navigation, route }: Props) {
     if (!name.trim()) return;
     setLoading(true);
     try {
-      const res = await fetch(`${API_URL}/habits/${id}`, {
+      const res = await authorizedFetch(`${API_URL}/habits/${id}`, {
         method: "PUT",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: name.trim(),
           notes: notes.trim() || null,

--- a/apps/mobile/src/screens/HabitDetailScreen.tsx
+++ b/apps/mobile/src/screens/HabitDetailScreen.tsx
@@ -39,15 +39,13 @@ function freqLabel(frequency: { type: string; count: number }): string {
 
 export default function HabitDetailScreen({ route, navigation }: Props) {
   const { id, name, notes, frequency } = route.params;
-  const { token } = useAuth();
+  const { token, authorizedFetch } = useAuth();
   const [allDays, setAllDays] = useState<Record<string, DayStatus>>({});
 
   useFocusEffect(
     useCallback(() => {
       if (!token) return;
-      fetch(`${API_URL}/habit-days`, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
+      authorizedFetch(`${API_URL}/habit-days`)
         .then((r) => r.json())
         .then((data: any[]) => {
           const map: Record<string, DayStatus> = {};
@@ -79,9 +77,8 @@ export default function HabitDetailScreen({ route, navigation }: Props) {
         style: "destructive",
         onPress: async () => {
           try {
-            const res = await fetch(`${API_URL}/habits/${id}`, {
+            const res = await authorizedFetch(`${API_URL}/habits/${id}`, {
               method: "DELETE",
-              headers: { Authorization: `Bearer ${token}` },
             });
             if (res.ok) {
               navigation.goBack();

--- a/apps/mobile/src/screens/HabitsScreen.tsx
+++ b/apps/mobile/src/screens/HabitsScreen.tsx
@@ -24,7 +24,7 @@ type Mode = "+" | "-" | null;
 
 
 export default function HabitsScreen() {
-  const { token } = useAuth();
+  const { token, authorizedFetch } = useAuth();
   const navigation = useNavigation<Nav>();
   const [habits, setHabits] = useState<any[]>([]);
   const [todayStatuses, setTodayStatuses] = useState<Record<string, DayStatus>>({});
@@ -41,12 +41,8 @@ export default function HabitsScreen() {
     const today = todayISO();
 
     Promise.all([
-      fetch(`${API_URL}/habits`, {
-        headers: { Authorization: `Bearer ${token}` },
-      }).then((r) => r.json()),
-      fetch(`${API_URL}/habit-days`, {
-        headers: { Authorization: `Bearer ${token}` },
-      }).then((r) => r.json()),
+      authorizedFetch(`${API_URL}/habits`).then((r) => r.json()),
+      authorizedFetch(`${API_URL}/habit-days`).then((r) => r.json()),
     ])
       .then(([habitsData, daysData]) => {
         setHabits(Array.isArray(habitsData) ? habitsData : []);
@@ -73,12 +69,9 @@ export default function HabitsScreen() {
     setTodayStatuses((prev) => ({ ...prev, [habitId]: next }));
 
     try {
-      const res = await fetch(`${API_URL}/habit-days`, {
+      const res = await authorizedFetch(`${API_URL}/habit-days`, {
         method: "PUT",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ habitId, date: today, status: next }),
       });
       if (!res.ok) {
@@ -116,9 +109,8 @@ export default function HabitsScreen() {
         style: "destructive",
         onPress: async () => {
           try {
-            const res = await fetch(`${API_URL}/habits/${habitId}`, {
+            const res = await authorizedFetch(`${API_URL}/habits/${habitId}`, {
               method: "DELETE",
-              headers: { Authorization: `Bearer ${token}` },
             });
             if (!res.ok) {
               const body = await res.json();

--- a/apps/mobile/src/screens/LoginScreen.tsx
+++ b/apps/mobile/src/screens/LoginScreen.tsx
@@ -39,7 +39,7 @@ export default function LoginScreen({ navigation }: Props) {
       });
       const data = await res.json();
       if (data.token) {
-        await login(data.token);
+        await login(data.token, data.refreshToken);
       } else {
         setError(data.error ?? "Invalid email or password.");
       }

--- a/apps/mobile/src/screens/ProfileScreen.tsx
+++ b/apps/mobile/src/screens/ProfileScreen.tsx
@@ -29,7 +29,7 @@ function getEmailFromToken(token: string): string {
 }
 
 export default function ProfileScreen() {
-  const { token, logout } = useAuth();
+  const { token, logout, authorizedFetch } = useAuth();
   const [habits, setHabits] = useState<any[]>([]);
   const [allDays, setAllDays] = useState<any[]>([]);
 
@@ -44,12 +44,8 @@ export default function ProfileScreen() {
   useEffect(() => {
     if (!token || !isFocused) return;
     Promise.all([
-      fetch(`${API_URL}/habits`, {
-        headers: { Authorization: `Bearer ${token}` },
-      }).then((r) => r.json()),
-      fetch(`${API_URL}/habit-days`, {
-        headers: { Authorization: `Bearer ${token}` },
-      }).then((r) => r.json()),
+      authorizedFetch(`${API_URL}/habits`).then((r) => r.json()),
+      authorizedFetch(`${API_URL}/habit-days`).then((r) => r.json()),
     ])
       .then(([habitsData, daysData]) => {
         setHabits(Array.isArray(habitsData) ? habitsData : []);

--- a/apps/mobile/src/screens/WeekScreen.tsx
+++ b/apps/mobile/src/screens/WeekScreen.tsx
@@ -18,7 +18,7 @@ const VIEW_OPTIONS: { key: ViewMode; label: string }[] = [
 ];
 
 export default function WeekScreen() {
-  const { token } = useAuth();
+  const { token, authorizedFetch } = useAuth();
   const isFocused = useIsFocused();
 
   const [viewMode, setViewMode] = useState<ViewMode>("weekly");
@@ -39,15 +39,9 @@ export default function WeekScreen() {
     if (!token || !isFocused) return;
 
     Promise.all([
-      fetch(`${API_URL}/habits`, {
-        headers: { Authorization: `Bearer ${token}` },
-      }).then((r) => r.json()),
-      fetch(`${API_URL}/habit-days`, {
-        headers: { Authorization: `Bearer ${token}` },
-      }).then((r) => r.json()),
-      fetch(`${API_URL}/habit-logs`, {
-        headers: { Authorization: `Bearer ${token}` },
-      }).then((r) => r.json()),
+      authorizedFetch(`${API_URL}/habits`).then((r) => r.json()),
+      authorizedFetch(`${API_URL}/habit-days`).then((r) => r.json()),
+      authorizedFetch(`${API_URL}/habit-logs`).then((r) => r.json()),
     ])
       .then(([habitsData, daysData, logsData]) => {
         setHabits(Array.isArray(habitsData) ? habitsData : []);
@@ -75,12 +69,9 @@ export default function WeekScreen() {
     }));
 
     try {
-      const res = await fetch(`${API_URL}/habit-days`, {
+      const res = await authorizedFetch(`${API_URL}/habit-days`, {
         method: "PUT",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ habitId, date: dayISO, status: next }),
       });
       if (!res.ok) {
@@ -113,12 +104,9 @@ export default function WeekScreen() {
     setLogs((prev) => [optimisticLog, ...prev]);
 
     try {
-      const res = await fetch(`${API_URL}/habit-logs`, {
+      const res = await authorizedFetch(`${API_URL}/habit-logs`, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ habitId }),
       });
       if (!res.ok) throw new Error("Failed to log");
@@ -135,9 +123,8 @@ export default function WeekScreen() {
     setLogs((prev) => prev.filter((l) => l.id !== logId));
 
     try {
-      const res = await fetch(`${API_URL}/habit-logs/${logId}`, {
+      const res = await authorizedFetch(`${API_URL}/habit-logs/${logId}`, {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
       });
       if (!res.ok) throw new Error("Failed to delete");
     } catch {

--- a/packages/db/prisma/migrations/20260726191323_add_refresh_token/migration.sql
+++ b/packages/db/prisma/migrations/20260726191323_add_refresh_token/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "RefreshToken" (
+    "id" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RefreshToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_tokenHash_key" ON "RefreshToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "RefreshToken_userId_idx" ON "RefreshToken"("userId");
+
+-- AddForeignKey
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -10,12 +10,29 @@ datasource db {
 }
 
 model User {
+  id            String         @id @default(cuid())
+  email         String         @unique
+  password      String
+  habits        Habit[]
+  refreshTokens RefreshToken[]
+  createdAt     DateTime       @default(now())
+  updatedAt     DateTime       @updatedAt
+}
+
+// Opaque, rotated on every use — only the SHA-256 hash is stored, so a leaked
+// DB doesn't hand out usable tokens. expiresAt slides forward 30 days on each
+// successful refresh, so an active user never has to log back in, but 30 days
+// of inactivity forces a real re-login.
+model RefreshToken {
   id        String   @id @default(cuid())
-  email     String   @unique
-  password  String
-  habits    Habit[]
+  tokenHash String   @unique
+  userId    String
+  expiresAt DateTime
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
 }
 
 model Habit {


### PR DESCRIPTION
## Summary
- Fixes a real bug: mobile never checked for a 401 anywhere, so an expired 1h access token meant every screen silently showed nothing while the user still looked "logged in"
- Adds rotating opaque refresh tokens (stored server-side only as a SHA-256 hash) with a 30-day sliding expiry — active users never have to re-login, 30 days of inactivity forces a real one
- `authorizedFetch` (in `AuthContext`) transparently refreshes on a 401 and retries once; if the refresh token itself is invalid/expired, it logs out and the user lands on Login instead of a broken screen
- Dedupes concurrent refreshes (e.g. Calendar screen's 3 parallel fetches) so N simultaneous 401s don't each rotate the token and stomp on each other

## Database
- New `RefreshToken` model, additive migration only (new table, nothing else touched)
- Note: this migration already landed on the prod DB (an accidental `prisma migrate dev` pointed at prod instead of a dev branch — safe since it's purely additive, but flagging for the record)

## Test plan
- [ ] Log in, wait past 1h (or manually expire a token), confirm the next action silently refreshes instead of showing blank data
- [ ] Confirm logging out actually revokes the refresh token server-side (POST /auth/logout)
- [ ] Confirm a truly dead/invalid refresh token redirects cleanly to Login
- [ ] Ship as OTA update (JS-only, no new native module) once merged + Render redeployed