### PR TITLE
Local habit reminders + Notification Settings screen

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,7 @@ import cors from "cors";
 import habitsRouter from "./routes/habits.routes";
 import habitDay from "./routes/habitDay.routes";
 import habitLog from "./routes/habitLog.routes";
+import notifications from "./routes/notifications.routes";
 import authRouter from "./routes/auth.routes";
 import { requireAuth } from "./middleware/requireAuth";
 
@@ -30,6 +31,7 @@ app.use("/auth", authRouter);
 app.use("/habits", requireAuth, habitsRouter);
 app.use("/habit-days", requireAuth, habitDay);
 app.use("/habit-logs", requireAuth, habitLog);
+app.use("/notifications", requireAuth, notifications);
 
 const port = process.env.PORT ?? 4000;
 app.listen(port, () => console.log(`Server running on http://localhost:${port}`));

--- a/apps/api/src/routes/notifications.routes.ts
+++ b/apps/api/src/routes/notifications.routes.ts
@@ -1,0 +1,114 @@
+import { Router } from "express";
+import { prisma } from "../../../../packages/db/src/prisma";
+import type { AuthRequest } from "../middleware/requireAuth";
+
+const router = Router();
+
+const VALID_CADENCES = ["DAILY", "WEEKLY", "MONTHLY", "YEARLY"];
+
+function validRule(body: any): body is { habitId?: string; cadence: string; hour: number; minute: number } {
+  if (!VALID_CADENCES.includes(body.cadence)) return false;
+  if (!Number.isInteger(body.hour) || body.hour < 0 || body.hour > 23) return false;
+  if (!Number.isInteger(body.minute) || body.minute < 0 || body.minute > 59) return false;
+  return true;
+}
+
+// GET /notifications — master toggle + all rules, everything the app needs
+// to resync its local notification schedule in one call
+router.get("/", async (req, res) => {
+  const { userId } = (req as AuthRequest).user;
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { notificationsEnabled: true },
+  });
+  const rules = await prisma.notificationRule.findMany({
+    where: { userId },
+    include: { habit: { select: { id: true, name: true } } },
+    orderBy: { createdAt: "asc" },
+  });
+
+  res.json({ enabled: user?.notificationsEnabled ?? false, rules });
+});
+
+// PUT /notifications/settings — master on/off switch
+router.put("/settings", async (req, res) => {
+  const { userId } = (req as AuthRequest).user;
+  const { enabled } = req.body;
+
+  if (typeof enabled !== "boolean") {
+    return res.status(400).json({ error: "enabled must be a boolean" });
+  }
+
+  await prisma.user.update({ where: { id: userId }, data: { notificationsEnabled: enabled } });
+  res.json({ enabled });
+});
+
+// POST /notifications/rules — add a reminder (habitId optional — omit for a
+// general reminder not tied to any one habit, e.g. an end-of-day nudge)
+router.post("/rules", async (req, res) => {
+  const { userId } = (req as AuthRequest).user;
+  const { habitId, cadence, hour, minute } = req.body;
+
+  if (!validRule(req.body)) {
+    return res.status(400).json({ error: "cadence, hour (0-23), and minute (0-59) are required" });
+  }
+
+  if (habitId) {
+    const habit = await prisma.habit.findFirst({ where: { id: habitId, userId } });
+    if (!habit) return res.status(404).json({ error: "Habit not found" });
+  }
+
+  const rule = await prisma.notificationRule.create({
+    data: { userId, habitId: habitId ?? null, cadence, hour, minute },
+    include: { habit: { select: { id: true, name: true } } },
+  });
+  res.status(201).json(rule);
+});
+
+// PUT /notifications/rules/:id — edit an existing rule (time, cadence, habit, or enabled)
+router.put("/rules/:id", async (req, res) => {
+  const { userId } = (req as unknown as AuthRequest).user;
+  const { id } = req.params;
+  const { habitId, cadence, hour, minute, enabled } = req.body;
+
+  const existing = await prisma.notificationRule.findFirst({ where: { id, userId } });
+  if (!existing) return res.status(404).json({ error: "Rule not found" });
+
+  if ((cadence !== undefined || hour !== undefined || minute !== undefined) &&
+      !validRule({ cadence: cadence ?? existing.cadence, hour: hour ?? existing.hour, minute: minute ?? existing.minute })) {
+    return res.status(400).json({ error: "cadence, hour (0-23), and minute (0-59) are required" });
+  }
+
+  if (habitId) {
+    const habit = await prisma.habit.findFirst({ where: { id: habitId, userId } });
+    if (!habit) return res.status(404).json({ error: "Habit not found" });
+  }
+
+  const rule = await prisma.notificationRule.update({
+    where: { id },
+    data: {
+      ...(habitId !== undefined && { habitId: habitId || null }),
+      ...(cadence !== undefined && { cadence }),
+      ...(hour !== undefined && { hour }),
+      ...(minute !== undefined && { minute }),
+      ...(enabled !== undefined && { enabled: Boolean(enabled) }),
+    },
+    include: { habit: { select: { id: true, name: true } } },
+  });
+  res.json(rule);
+});
+
+// DELETE /notifications/rules/:id
+router.delete("/rules/:id", async (req, res) => {
+  const { userId } = (req as unknown as AuthRequest).user;
+  const { id } = req.params;
+
+  const existing = await prisma.notificationRule.findFirst({ where: { id, userId } });
+  if (!existing) return res.status(404).json({ error: "Rule not found" });
+
+  await prisma.notificationRule.delete({ where: { id } });
+  res.status(204).send();
+});
+
+export default router;

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -2,6 +2,12 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { AuthProvider } from './src/context/AuthContext';
 import RootNavigator from './src/navigation/RootNavigator';
 import { useAppUpdates } from './src/hooks/useAppUpdates';
+import { useNotificationOnboarding } from './src/hooks/useNotificationOnboarding';
+
+function AppContent() {
+  useNotificationOnboarding();
+  return <RootNavigator />;
+}
 
 export default function App() {
   useAppUpdates();
@@ -9,7 +15,7 @@ export default function App() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <AuthProvider>
-        <RootNavigator />
+        <AppContent />
       </AuthProvider>
     </GestureHandlerRootView>
   );

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -27,7 +27,13 @@
       "favicon": "./assets/favicon.png"
     },
     "plugins": [
-      "expo-secure-store"
+      "expo-secure-store",
+      [
+        "expo-notifications",
+        {
+          "color": "#009951"
+        }
+      ]
     ],
     "extra": {
       "eas": {

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -12,6 +12,7 @@
         "@react-navigation/native": "^7.3.3",
         "@react-navigation/native-stack": "^7.17.5",
         "expo": "~54.0.0",
+        "expo-notifications": "~0.32.17",
         "expo-secure-store": "~15.0.8",
         "expo-status-bar": "~3.0.9",
         "expo-updates": "~29.0.18",
@@ -2174,6 +2175,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@ide/backoff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
+      "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==",
+      "license": "MIT"
+    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -3113,11 +3120,39 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -3337,6 +3372,12 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/badgin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/badgin/-/badgin-1.2.3.tgz",
+      "integrity": "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3540,6 +3581,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/camelcase": {
@@ -3991,6 +4079,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -3998,6 +4103,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/depd": {
@@ -4110,6 +4232,20 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -4167,11 +4303,32 @@
         "stackframe": "^1.3.4"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -4284,6 +4441,15 @@
         "react-native-webview": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-application": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-7.0.8.tgz",
+      "integrity": "sha512-qFGyxk7VJbrNOQWBbE09XUuGuvkOgFS9QfToaK2FdagM2aQ+x3CvGV2DuVgl/l4ZxPgIf3b/MNh9xHpwSwn74Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-asset": {
@@ -4399,6 +4565,26 @@
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-notifications": {
+      "version": "0.32.17",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-0.32.17.tgz",
+      "integrity": "sha512-lwwzn7tImuzTzn9PAglZlS2VfZEvsfFGJTK9Eb8I4cqkGh2DI23YJFJH+WPEIu4QhDvk5JeBjklenJ8IZbmA4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.8.8",
+        "@ide/backoff": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "assert": "^2.0.0",
+        "badgin": "^1.1.5",
+        "expo-application": "~7.0.8",
+        "expo-constants": "~18.0.13"
+      },
+      "peerDependencies": {
+        "expo": "*",
         "react": "*",
         "react-native": "*"
       }
@@ -4608,6 +4794,21 @@
       "integrity": "sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/freeport-async": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/freeport-async/-/freeport-async-2.0.0.tgz",
@@ -4655,6 +4856,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -4673,6 +4883,30 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -4680,6 +4914,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/getenv": {
@@ -4744,6 +4991,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4757,6 +5016,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -4946,11 +5244,39 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "license": "MIT"
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-core-module": {
       "version": "2.16.2",
@@ -4991,6 +5317,41 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4998,6 +5359,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-wsl": {
@@ -5762,6 +6156,15 @@
       "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
@@ -6381,6 +6784,51 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -6702,6 +7150,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -7385,6 +7842,23 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/sax": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
@@ -7512,6 +7986,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/setprototypeof": {
@@ -8220,6 +8711,19 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -8329,6 +8833,27 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/wonka": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -7,6 +7,7 @@
     "@react-navigation/native": "^7.3.3",
     "@react-navigation/native-stack": "^7.17.5",
     "expo": "~54.0.0",
+    "expo-notifications": "~0.32.17",
     "expo-secure-store": "~15.0.8",
     "expo-status-bar": "~3.0.9",
     "expo-updates": "~29.0.18",

--- a/apps/mobile/src/hooks/useNotificationOnboarding.ts
+++ b/apps/mobile/src/hooks/useNotificationOnboarding.ts
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+import { Alert } from "react-native";
+import * as SecureStore from "expo-secure-store";
+import * as Notifications from "expo-notifications";
+import { useAuth } from "../context/AuthContext";
+import { API_URL } from "../api/client";
+
+const PROMPTED_KEY = "notificationsPrompted";
+
+// Fires once ever, the first time a token becomes available (covers both a
+// brand new registration and an existing user's first launch after this
+// feature ships) — never nags again after the first answer either way.
+export function useNotificationOnboarding() {
+  const { token, authorizedFetch } = useAuth();
+
+  useEffect(() => {
+    if (!token) return;
+
+    (async () => {
+      const alreadyPrompted = await SecureStore.getItemAsync(PROMPTED_KEY);
+      if (alreadyPrompted) return;
+      await SecureStore.setItemAsync(PROMPTED_KEY, "1");
+
+      Alert.alert(
+        "Stay on track",
+        "Get reminders for your habits — daily check-ins, weekly summaries, or custom alerts you set up yourself. You can change this anytime in Profile.",
+        [
+          { text: "Not now", style: "cancel" },
+          {
+            text: "Enable",
+            onPress: async () => {
+              const { status } = await Notifications.requestPermissionsAsync();
+              if (status !== "granted") return;
+
+              try {
+                await authorizedFetch(`${API_URL}/notifications/settings`, {
+                  method: "PUT",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ enabled: true }),
+                });
+              } catch {
+                // Settings screen will reflect the real state next time it's opened either way
+              }
+            },
+          },
+        ],
+      );
+    })();
+  }, [token]);
+}

--- a/apps/mobile/src/navigation/RootNavigator.tsx
+++ b/apps/mobile/src/navigation/RootNavigator.tsx
@@ -6,6 +6,7 @@ import RegisterScreen from "../screens/RegisterScreen";
 import CreateHabitScreen from "../screens/CreateHabitScreen";
 import EditHabitScreen from "../screens/EditHabitScreen";
 import HabitDetailScreen from "../screens/HabitDetailScreen";
+import NotificationSettingsScreen from "../screens/NotificationSettingsScreen";
 import TabNavigator from "./TabNavigator";
 import { AppStack, AuthStack } from "./types";
 
@@ -41,6 +42,11 @@ export default function RootNavigator() {
           <AppNavigator.Screen
             name="HabitDetail"
             component={HabitDetailScreen}
+            options={{ headerShown: false }}
+          />
+          <AppNavigator.Screen
+            name="NotificationSettings"
+            component={NotificationSettingsScreen}
             options={{ headerShown: false }}
           />
         </AppNavigator.Navigator>

--- a/apps/mobile/src/navigation/types.tsx
+++ b/apps/mobile/src/navigation/types.tsx
@@ -21,4 +21,5 @@ export type AppStack = {
   CreateHabit: undefined;
   EditHabit: { id: string; name: string; notes?: string | null; frequency: HabitFrequency };
   HabitDetail: { id: string; name: string; notes?: string | null; frequency: HabitFrequency };
+  NotificationSettings: undefined;
 };

--- a/apps/mobile/src/screens/NotificationSettingsScreen.tsx
+++ b/apps/mobile/src/screens/NotificationSettingsScreen.tsx
@@ -1,0 +1,534 @@
+import React, { useState, useEffect } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  ScrollView,
+  Modal,
+  Alert,
+  ActivityIndicator,
+} from "react-native";
+import { useIsFocused, useNavigation } from "@react-navigation/native";
+import * as Notifications from "expo-notifications";
+import { useAuth } from "../context/AuthContext";
+import { API_URL } from "../api/client";
+import { syncScheduledNotifications, sendTestNotification, NotificationRule, Cadence } from "../utils/notifications";
+
+const CADENCE_OPTIONS: { value: Cadence; label: string }[] = [
+  { value: "DAILY", label: "Daily" },
+  { value: "WEEKLY", label: "End of week" },
+  { value: "MONTHLY", label: "End of month" },
+  { value: "YEARLY", label: "End of year" },
+];
+
+const HOUR_OPTIONS = Array.from({ length: 24 }, (_, i) => i);
+const MINUTE_OPTIONS = [0, 15, 30, 45];
+
+function formatHourMinute(hour: number, minute: number): string {
+  const period = hour >= 12 ? "PM" : "AM";
+  const h12 = hour % 12 === 0 ? 12 : hour % 12;
+  return `${h12}:${minute.toString().padStart(2, "0")} ${period}`;
+}
+
+function cadenceLabel(c: Cadence): string {
+  const found = CADENCE_OPTIONS.find((o) => o.value === c);
+  return found ? found.label : c;
+}
+
+interface Habit {
+  id: string;
+  name: string;
+}
+
+export default function NotificationSettingsScreen() {
+  const { token, authorizedFetch } = useAuth();
+  const isFocused = useIsFocused();
+  const navigation = useNavigation();
+
+  const [enabled, setEnabled] = useState(false);
+  const [rules, setRules] = useState<NotificationRule[]>([]);
+  const [habits, setHabits] = useState<Habit[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const [modalVisible, setModalVisible] = useState(false);
+  const [editingRule, setEditingRule] = useState<NotificationRule | null>(null);
+  const [draftHabitId, setDraftHabitId] = useState<string | null>(null);
+  const [draftCadence, setDraftCadence] = useState<Cadence>("DAILY");
+  const [draftHour, setDraftHour] = useState(20);
+  const [draftMinute, setDraftMinute] = useState(0);
+
+  useEffect(() => {
+    if (!token || !isFocused) return;
+    setLoading(true);
+    Promise.all([
+      authorizedFetch(`${API_URL}/notifications`).then((r) => r.json()),
+      authorizedFetch(`${API_URL}/habits`).then((r) => r.json()),
+    ])
+      .then(([notifData, habitsData]) => {
+        setEnabled(notifData.enabled ?? false);
+        setRules(Array.isArray(notifData.rules) ? notifData.rules : []);
+        setHabits(Array.isArray(habitsData) ? habitsData : []);
+      })
+      .catch((err) => console.log("fetch error:", err))
+      .finally(() => setLoading(false));
+  }, [token, isFocused]);
+
+  // Keep the on-device OS schedule in sync any time the master toggle or rule list changes
+  useEffect(() => {
+    if (loading) return;
+    syncScheduledNotifications(enabled ? rules : []).catch((err) => console.log("sync error:", err));
+  }, [enabled, rules, loading]);
+
+  async function toggleMaster(next: boolean) {
+    if (next) {
+      const { status } = await Notifications.requestPermissionsAsync();
+      if (status !== "granted") {
+        Alert.alert("Permission needed", "Enable notifications for New Me in your device Settings first.");
+        return;
+      }
+    }
+    const prev = enabled;
+    setEnabled(next);
+    try {
+      const res = await authorizedFetch(`${API_URL}/notifications/settings`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: next }),
+      });
+      if (!res.ok) throw new Error();
+    } catch {
+      setEnabled(prev);
+      Alert.alert("Error", "Failed to update — try again");
+    }
+  }
+
+  function openAddModal() {
+    setEditingRule(null);
+    setDraftHabitId(null);
+    setDraftCadence("DAILY");
+    setDraftHour(20);
+    setDraftMinute(0);
+    setModalVisible(true);
+  }
+
+  function openEditModal(rule: NotificationRule) {
+    setEditingRule(rule);
+    setDraftHabitId(rule.habitId);
+    setDraftCadence(rule.cadence);
+    setDraftHour(rule.hour);
+    setDraftMinute(rule.minute);
+    setModalVisible(true);
+  }
+
+  async function saveDraft() {
+    const body = { habitId: draftHabitId, cadence: draftCadence, hour: draftHour, minute: draftMinute };
+    try {
+      if (editingRule) {
+        const res = await authorizedFetch(`${API_URL}/notifications/rules/${editingRule.id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) throw new Error();
+        const updated = await res.json();
+        setRules((prev) => prev.map((r) => (r.id === updated.id ? updated : r)));
+      } else {
+        const res = await authorizedFetch(`${API_URL}/notifications/rules`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) throw new Error();
+        const created = await res.json();
+        setRules((prev) => [...prev, created]);
+      }
+      setModalVisible(false);
+    } catch {
+      Alert.alert("Error", "Failed to save — try again");
+    }
+  }
+
+  function handleDelete(rule: NotificationRule) {
+    Alert.alert("Remove Reminder", "Are you sure?", [
+      { text: "Cancel" },
+      {
+        text: "Delete",
+        style: "destructive",
+        onPress: async () => {
+          const prev = rules;
+          setRules((rs) => rs.filter((r) => r.id !== rule.id));
+          try {
+            const res = await authorizedFetch(`${API_URL}/notifications/rules/${rule.id}`, { method: "DELETE" });
+            if (!res.ok) throw new Error();
+          } catch {
+            setRules(prev);
+            Alert.alert("Error", "Failed to delete — try again");
+          }
+        },
+      },
+    ]);
+  }
+
+  async function toggleRuleEnabled(rule: NotificationRule) {
+    const prev = rules;
+    setRules((rs) => rs.map((r) => (r.id === rule.id ? { ...r, enabled: !r.enabled } : r)));
+    try {
+      const res = await authorizedFetch(`${API_URL}/notifications/rules/${rule.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: !rule.enabled }),
+      });
+      if (!res.ok) throw new Error();
+    } catch {
+      setRules(prev);
+      Alert.alert("Error", "Failed to update — try again");
+    }
+  }
+
+  // TODO: remove once real scheduled reminders have been confirmed working on device —
+  // this exists purely so you don't have to wait a day/week/month/year to see one fire.
+  async function handleTestNotification() {
+    const { status } = await Notifications.requestPermissionsAsync();
+    if (status !== "granted") {
+      Alert.alert("Permission needed", "Enable notifications for New Me in your device Settings first.");
+      return;
+    }
+    await sendTestNotification();
+    Alert.alert("Sent", "You should see a notification in a few seconds — try locking your phone.");
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backBtn}>
+          <Text style={styles.backText}>‹ Back</Text>
+        </TouchableOpacity>
+        <Text style={styles.eyebrow}>SETTINGS</Text>
+        <Text style={styles.title}>Notifications</Text>
+      </View>
+
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <View style={styles.masterRow}>
+          <View>
+            <Text style={styles.masterLabel}>Enable Notifications</Text>
+            <Text style={styles.masterSub}>{enabled ? "On" : "Off"}</Text>
+          </View>
+          <TouchableOpacity
+            style={[styles.toggle, enabled && styles.toggleOn]}
+            onPress={() => toggleMaster(!enabled)}
+          >
+            <View style={[styles.toggleThumb, enabled && styles.toggleThumbOn]} />
+          </TouchableOpacity>
+        </View>
+
+        <TouchableOpacity style={styles.testBtn} onPress={handleTestNotification}>
+          <Text style={styles.testBtnText}>Send Test Notification</Text>
+        </TouchableOpacity>
+
+        <Text style={styles.sectionLabel}>REMINDERS</Text>
+
+        {loading ? (
+          <ActivityIndicator color="#98FF9D" />
+        ) : rules.length === 0 ? (
+          <Text style={styles.emptyText}>No reminders yet — add one below.</Text>
+        ) : (
+          rules.map((rule) => (
+            <TouchableOpacity key={rule.id} style={styles.ruleCard} onPress={() => openEditModal(rule)}>
+              <View style={styles.ruleInfo}>
+                <Text style={styles.ruleName}>{rule.habit?.name ?? "General reminder"}</Text>
+                <Text style={styles.ruleSub}>
+                  {cadenceLabel(rule.cadence)} · {formatHourMinute(rule.hour, rule.minute)}
+                </Text>
+              </View>
+              <TouchableOpacity
+                style={[styles.smallToggle, rule.enabled && styles.smallToggleOn]}
+                onPress={() => toggleRuleEnabled(rule)}
+              >
+                <View style={[styles.smallToggleThumb, rule.enabled && styles.smallToggleThumbOn]} />
+              </TouchableOpacity>
+              <TouchableOpacity onPress={() => handleDelete(rule)}>
+                <Text style={styles.removeText}>Remove</Text>
+              </TouchableOpacity>
+            </TouchableOpacity>
+          ))
+        )}
+
+        <TouchableOpacity style={styles.addBtn} onPress={openAddModal}>
+          <Text style={styles.addBtnText}>+ Add Reminder</Text>
+        </TouchableOpacity>
+      </ScrollView>
+
+      <Modal visible={modalVisible} transparent animationType="slide" onRequestClose={() => setModalVisible(false)}>
+        <View style={styles.modalRoot}>
+          <TouchableOpacity style={styles.backdrop} activeOpacity={1} onPress={() => setModalVisible(false)} />
+          <View style={styles.card}>
+            <View style={styles.handle} />
+            <Text style={styles.eyebrow}>{editingRule ? "EDIT REMINDER" : "NEW REMINDER"}</Text>
+
+            <Text style={styles.fieldLabel}>HABIT</Text>
+            <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.pillRow}>
+              <TouchableOpacity
+                style={[styles.pillBtn, draftHabitId === null && styles.pillBtnActive]}
+                onPress={() => setDraftHabitId(null)}
+              >
+                <Text style={[styles.pillText, draftHabitId === null && styles.pillTextActive]}>General</Text>
+              </TouchableOpacity>
+              {habits.map((h) => (
+                <TouchableOpacity
+                  key={h.id}
+                  style={[styles.pillBtn, draftHabitId === h.id && styles.pillBtnActive]}
+                  onPress={() => setDraftHabitId(h.id)}
+                >
+                  <Text
+                    style={[styles.pillText, draftHabitId === h.id && styles.pillTextActive]}
+                    numberOfLines={1}
+                  >
+                    {h.name}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </ScrollView>
+
+            <Text style={styles.fieldLabel}>FREQUENCY</Text>
+            <View style={styles.freqRow}>
+              {CADENCE_OPTIONS.map((opt) => (
+                <TouchableOpacity
+                  key={opt.value}
+                  style={[styles.freqBtn, draftCadence === opt.value && styles.freqBtnActive]}
+                  onPress={() => setDraftCadence(opt.value)}
+                >
+                  <Text style={[styles.freqBtnText, draftCadence === opt.value && styles.freqBtnTextActive]}>
+                    {opt.label}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+
+            <Text style={styles.fieldLabel}>TIME</Text>
+            <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.pillRow}>
+              {HOUR_OPTIONS.map((h) => (
+                <TouchableOpacity
+                  key={h}
+                  style={[styles.timeBtn, draftHour === h && styles.timeBtnActive]}
+                  onPress={() => setDraftHour(h)}
+                >
+                  <Text style={[styles.timeBtnText, draftHour === h && styles.timeBtnTextActive]}>
+                    {h % 12 === 0 ? 12 : h % 12}
+                    {h >= 12 ? "PM" : "AM"}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </ScrollView>
+            <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.pillRow}>
+              {MINUTE_OPTIONS.map((m) => (
+                <TouchableOpacity
+                  key={m}
+                  style={[styles.timeBtn, draftMinute === m && styles.timeBtnActive]}
+                  onPress={() => setDraftMinute(m)}
+                >
+                  <Text style={[styles.timeBtnText, draftMinute === m && styles.timeBtnTextActive]}>
+                    :{m.toString().padStart(2, "0")}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </ScrollView>
+
+            <TouchableOpacity style={styles.saveBtn} onPress={saveDraft}>
+              <Text style={styles.saveBtnText}>{editingRule ? "Save Changes" : "Add Reminder"}</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.cancelBtn} onPress={() => setModalVisible(false)}>
+              <Text style={styles.cancelBtnText}>Cancel</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#000603", paddingTop: 60 },
+  header: { paddingHorizontal: 20, paddingBottom: 12 },
+  backBtn: { marginBottom: 12 },
+  backText: { color: "#3a7a5a", fontSize: 16 },
+  eyebrow: {
+    fontSize: 10,
+    textTransform: "uppercase",
+    letterSpacing: 1.2,
+    color: "#3a7a5a",
+    marginBottom: 2,
+  },
+  title: { fontSize: 28, fontWeight: "400", color: "#98eaff" },
+  content: { paddingHorizontal: 20, paddingBottom: 110, gap: 12 },
+  masterRow: {
+    backgroundColor: "#085331",
+    borderRadius: 16,
+    padding: 18,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    shadowColor: "#000",
+    shadowOffset: { width: -4, height: 4 },
+    shadowOpacity: 0.4,
+    shadowRadius: 12,
+    elevation: 6,
+  },
+  masterLabel: { fontSize: 16, color: "#98eaff" },
+  masterSub: { fontSize: 12, color: "#3a7a5a", marginTop: 2 },
+  toggle: {
+    width: 50,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: "#000",
+    padding: 3,
+    borderWidth: 1,
+    borderColor: "rgba(152,234,255,0.15)",
+  },
+  toggleOn: { backgroundColor: "#009951", borderColor: "#009951" },
+  toggleThumb: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    backgroundColor: "#3a7a5a",
+  },
+  toggleThumbOn: { backgroundColor: "#fff", alignSelf: "flex-end" },
+  testBtn: {
+    alignSelf: "flex-start",
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "#009951",
+  },
+  testBtnText: { fontSize: 13, color: "#98FF9D", fontWeight: "600" },
+  sectionLabel: {
+    fontSize: 10,
+    textTransform: "uppercase",
+    letterSpacing: 1.2,
+    color: "#3a7a5a",
+    marginTop: 4,
+  },
+  emptyText: { fontSize: 13, color: "#3a7a5a" },
+  ruleCard: {
+    backgroundColor: "#085331",
+    borderRadius: 14,
+    padding: 14,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    shadowColor: "#000",
+    shadowOffset: { width: -4, height: 4 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  ruleInfo: { flex: 1 },
+  ruleName: { fontSize: 15, color: "#98eaff" },
+  ruleSub: { fontSize: 12, color: "#3a7a5a", marginTop: 2 },
+  smallToggle: {
+    width: 40,
+    height: 22,
+    borderRadius: 11,
+    backgroundColor: "#000",
+    padding: 2,
+    borderWidth: 1,
+    borderColor: "rgba(152,234,255,0.15)",
+  },
+  smallToggleOn: { backgroundColor: "#009951", borderColor: "#009951" },
+  smallToggleThumb: {
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    backgroundColor: "#3a7a5a",
+  },
+  smallToggleThumbOn: { backgroundColor: "#fff", alignSelf: "flex-end" },
+  removeText: { fontSize: 12, color: "rgba(255,85,85,0.7)" },
+  addBtn: {
+    borderRadius: 14,
+    padding: 14,
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "rgba(152,255,157,0.25)",
+    borderStyle: "dashed",
+  },
+  addBtnText: { fontSize: 14, color: "#98FF9D" },
+  modalRoot: { flex: 1, justifyContent: "flex-end" },
+  backdrop: { ...StyleSheet.absoluteFillObject, backgroundColor: "rgba(0,0,0,0.6)" },
+  card: {
+    backgroundColor: "#05170e",
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    paddingHorizontal: 24,
+    paddingTop: 12,
+    paddingBottom: 40,
+    borderWidth: 1,
+    borderBottomWidth: 0,
+    borderColor: "rgba(152, 255, 157, 0.15)",
+  },
+  handle: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: "#3a7a5a",
+    alignSelf: "center",
+    marginBottom: 20,
+  },
+  fieldLabel: {
+    fontSize: 10,
+    textTransform: "uppercase",
+    letterSpacing: 1.2,
+    color: "#3a7a5a",
+    marginBottom: 8,
+    marginTop: 16,
+  },
+  pillRow: { gap: 8, paddingVertical: 2 },
+  pillBtn: {
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "rgba(152,234,255,0.15)",
+    backgroundColor: "#001b0e",
+    maxWidth: 140,
+  },
+  pillBtnActive: { backgroundColor: "#085331", borderColor: "#009951" },
+  pillText: { fontSize: 13, color: "#3a7a5a" },
+  pillTextActive: { color: "#98FF9D", fontWeight: "600" },
+  freqRow: { flexDirection: "row", gap: 8 },
+  freqBtn: {
+    flex: 1,
+    paddingVertical: 10,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "rgba(152,234,255,0.15)",
+    backgroundColor: "#001b0e",
+    alignItems: "center",
+  },
+  freqBtnActive: { backgroundColor: "#085331", borderColor: "#009951" },
+  freqBtnText: { fontSize: 11, color: "#3a7a5a", textAlign: "center" },
+  freqBtnTextActive: { color: "#98FF9D", fontWeight: "600" },
+  timeBtn: {
+    width: 56,
+    paddingVertical: 10,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "rgba(152,234,255,0.15)",
+    backgroundColor: "#001b0e",
+    alignItems: "center",
+  },
+  timeBtnActive: { backgroundColor: "#085331", borderColor: "#009951" },
+  timeBtnText: { fontSize: 13, color: "#3a7a5a" },
+  timeBtnTextActive: { color: "#98FF9D", fontWeight: "600" },
+  saveBtn: {
+    backgroundColor: "#009951",
+    padding: 16,
+    borderRadius: 12,
+    alignItems: "center",
+    marginTop: 24,
+    marginBottom: 12,
+  },
+  saveBtnText: { color: "#fff", fontSize: 16, fontWeight: "600" },
+  cancelBtn: { alignSelf: "center", padding: 8 },
+  cancelBtnText: { color: "#3a7a5a", fontSize: 14 },
+});

--- a/apps/mobile/src/screens/NotificationSettingsScreen.tsx
+++ b/apps/mobile/src/screens/NotificationSettingsScreen.tsx
@@ -13,7 +13,7 @@ import { useIsFocused, useNavigation } from "@react-navigation/native";
 import * as Notifications from "expo-notifications";
 import { useAuth } from "../context/AuthContext";
 import { API_URL } from "../api/client";
-import { syncScheduledNotifications, sendTestNotification, NotificationRule, Cadence } from "../utils/notifications";
+import { syncScheduledNotifications, NotificationRule, Cadence } from "../utils/notifications";
 
 const CADENCE_OPTIONS: { value: Cadence; label: string }[] = [
   { value: "DAILY", label: "Daily" },
@@ -186,18 +186,6 @@ export default function NotificationSettingsScreen() {
     }
   }
 
-  // TODO: remove once real scheduled reminders have been confirmed working on device —
-  // this exists purely so you don't have to wait a day/week/month/year to see one fire.
-  async function handleTestNotification() {
-    const { status } = await Notifications.requestPermissionsAsync();
-    if (status !== "granted") {
-      Alert.alert("Permission needed", "Enable notifications for New Me in your device Settings first.");
-      return;
-    }
-    await sendTestNotification();
-    Alert.alert("Sent", "You should see a notification in a few seconds — try locking your phone.");
-  }
-
   return (
     <View style={styles.container}>
       <View style={styles.header}>
@@ -221,10 +209,6 @@ export default function NotificationSettingsScreen() {
             <View style={[styles.toggleThumb, enabled && styles.toggleThumbOn]} />
           </TouchableOpacity>
         </View>
-
-        <TouchableOpacity style={styles.testBtn} onPress={handleTestNotification}>
-          <Text style={styles.testBtnText}>Send Test Notification</Text>
-        </TouchableOpacity>
 
         <Text style={styles.sectionLabel}>REMINDERS</Text>
 
@@ -393,15 +377,6 @@ const styles = StyleSheet.create({
     backgroundColor: "#3a7a5a",
   },
   toggleThumbOn: { backgroundColor: "#fff", alignSelf: "flex-end" },
-  testBtn: {
-    alignSelf: "flex-start",
-    paddingHorizontal: 14,
-    paddingVertical: 10,
-    borderRadius: 10,
-    borderWidth: 1,
-    borderColor: "#009951",
-  },
-  testBtnText: { fontSize: 13, color: "#98FF9D", fontWeight: "600" },
   sectionLabel: {
     fontSize: 10,
     textTransform: "uppercase",

--- a/apps/mobile/src/screens/ProfileScreen.tsx
+++ b/apps/mobile/src/screens/ProfileScreen.tsx
@@ -6,9 +6,11 @@ import {
   TouchableOpacity,
   StyleSheet,
 } from "react-native";
-import { useIsFocused } from "@react-navigation/native";
+import { useIsFocused, useNavigation } from "@react-navigation/native";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useAuth } from "../context/AuthContext";
 import { API_URL } from "../api/client";
+import { AppStack } from "../navigation/types";
 import {
   todayISO,
   getMondayISO,
@@ -17,6 +19,7 @@ import {
 import { calculateStreak } from "../utils/streak";
 
 type DayStatus = "UNSET" | "DONE" | "MISSED";
+type Nav = NativeStackNavigationProp<AppStack>;
 
 // Decode JWT payload to extract user email without a library
 function getEmailFromToken(token: string): string {
@@ -30,6 +33,7 @@ function getEmailFromToken(token: string): string {
 
 export default function ProfileScreen() {
   const { token, logout, authorizedFetch } = useAuth();
+  const navigation = useNavigation<Nav>();
   const [habits, setHabits] = useState<any[]>([]);
   const [allDays, setAllDays] = useState<any[]>([]);
 
@@ -179,6 +183,14 @@ export default function ProfileScreen() {
             })}
           </View>
         )}
+
+        {/* Notification settings */}
+        <TouchableOpacity
+          style={styles.notifBtn}
+          onPress={() => navigation.navigate("NotificationSettings")}
+        >
+          <Text style={styles.notifBtnText}>Notifications</Text>
+        </TouchableOpacity>
 
         {/* Sign out */}
         <TouchableOpacity style={styles.signOutBtn} onPress={logout}>
@@ -340,6 +352,19 @@ const styles = StyleSheet.create({
     color: "#3a7a5a",
     width: 28,
     textAlign: "right",
+  },
+  notifBtn: {
+    alignSelf: "center",
+    paddingVertical: 12,
+    paddingHorizontal: 32,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "rgba(152,234,255,0.15)",
+    marginTop: 4,
+  },
+  notifBtnText: {
+    color: "#98eaff",
+    fontSize: 14,
   },
   signOutBtn: {
     alignSelf: "center",

--- a/apps/mobile/src/utils/notifications.ts
+++ b/apps/mobile/src/utils/notifications.ts
@@ -104,14 +104,3 @@ export async function syncScheduledNotifications(rules: NotificationRule[]): Pro
     }
   }
 }
-
-export async function sendTestNotification(): Promise<void> {
-  await Notifications.scheduleNotificationAsync({
-    content: { title: "New Me", body: "Test notification — if you see this, it works." },
-    trigger: {
-      type: Notifications.SchedulableTriggerInputTypes.TIME_INTERVAL,
-      seconds: 3,
-      repeats: false,
-    },
-  });
-}

--- a/apps/mobile/src/utils/notifications.ts
+++ b/apps/mobile/src/utils/notifications.ts
@@ -1,0 +1,117 @@
+import * as Notifications from "expo-notifications";
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowBanner: true,
+    shouldShowList: true,
+    shouldPlaySound: true,
+    shouldSetBadge: false,
+  }),
+});
+
+export type Cadence = "DAILY" | "WEEKLY" | "MONTHLY" | "YEARLY";
+
+export interface NotificationRule {
+  id: string;
+  habitId: string | null;
+  habit?: { id: string; name: string } | null;
+  cadence: Cadence;
+  hour: number;
+  minute: number;
+  enabled: boolean;
+}
+
+function bodyForRule(rule: NotificationRule): string {
+  if (rule.habit) return `Don't forget: ${rule.habit.name}`;
+  switch (rule.cadence) {
+    case "DAILY":
+      return "Time for your daily check-in.";
+    case "WEEKLY":
+      return "How did this week go? Log your habits.";
+    case "MONTHLY":
+      return "Wrap up the month — check your habits.";
+    case "YEARLY":
+      return "Reflect on the year — check your habits.";
+  }
+}
+
+// Native MONTHLY triggers fire on a fixed day-of-month and silently skip any
+// month shorter than that (day 31 never fires in February), so "end of
+// month" can't be a repeating native trigger — instead we compute the real
+// last day of the current (or next, if already past) month and schedule a
+// one-off DATE trigger. syncScheduledNotifications reschedules this on every
+// app open, so it self-heals as long as the app opens at least once between
+// month-ends.
+function nextEndOfMonth(hour: number, minute: number): Date {
+  const now = new Date();
+  let candidate = new Date(now.getFullYear(), now.getMonth() + 1, 0, hour, minute, 0);
+  if (candidate <= now) {
+    candidate = new Date(now.getFullYear(), now.getMonth() + 2, 0, hour, minute, 0);
+  }
+  return candidate;
+}
+
+// Cancels every locally scheduled notification and reschedules from the
+// current rule set — simplest way to keep the OS schedule in sync without
+// tracking individual notification IDs against rule edits/deletes.
+export async function syncScheduledNotifications(rules: NotificationRule[]): Promise<void> {
+  await Notifications.cancelAllScheduledNotificationsAsync();
+
+  for (const rule of rules) {
+    if (!rule.enabled) continue;
+    const content = { title: "New Me", body: bodyForRule(rule) };
+
+    if (rule.cadence === "DAILY") {
+      await Notifications.scheduleNotificationAsync({
+        content,
+        trigger: {
+          type: Notifications.SchedulableTriggerInputTypes.DAILY,
+          hour: rule.hour,
+          minute: rule.minute,
+        },
+      });
+    } else if (rule.cadence === "WEEKLY") {
+      // weekday 1 = Sunday — last day of the Monday-start week used elsewhere in this app
+      await Notifications.scheduleNotificationAsync({
+        content,
+        trigger: {
+          type: Notifications.SchedulableTriggerInputTypes.WEEKLY,
+          weekday: 1,
+          hour: rule.hour,
+          minute: rule.minute,
+        },
+      });
+    } else if (rule.cadence === "YEARLY") {
+      // Dec 31 always exists, so this can be a real repeating native trigger
+      await Notifications.scheduleNotificationAsync({
+        content,
+        trigger: {
+          type: Notifications.SchedulableTriggerInputTypes.YEARLY,
+          month: 11,
+          day: 31,
+          hour: rule.hour,
+          minute: rule.minute,
+        },
+      });
+    } else if (rule.cadence === "MONTHLY") {
+      await Notifications.scheduleNotificationAsync({
+        content,
+        trigger: {
+          type: Notifications.SchedulableTriggerInputTypes.DATE,
+          date: nextEndOfMonth(rule.hour, rule.minute),
+        },
+      });
+    }
+  }
+}
+
+export async function sendTestNotification(): Promise<void> {
+  await Notifications.scheduleNotificationAsync({
+    content: { title: "New Me", body: "Test notification — if you see this, it works." },
+    trigger: {
+      type: Notifications.SchedulableTriggerInputTypes.TIME_INTERVAL,
+      seconds: 3,
+      repeats: false,
+    },
+  });
+}

--- a/packages/db/prisma/migrations/20260726201012_add_notification_rule/migration.sql
+++ b/packages/db/prisma/migrations/20260726201012_add_notification_rule/migration.sql
@@ -1,0 +1,26 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "notificationsEnabled" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "NotificationRule" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "habitId" TEXT,
+    "cadence" "FrequencyType" NOT NULL,
+    "hour" INTEGER NOT NULL,
+    "minute" INTEGER NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "NotificationRule_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "NotificationRule_userId_idx" ON "NotificationRule"("userId");
+
+-- AddForeignKey
+ALTER TABLE "NotificationRule" ADD CONSTRAINT "NotificationRule_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "NotificationRule" ADD CONSTRAINT "NotificationRule_habitId_fkey" FOREIGN KEY ("habitId") REFERENCES "Habit"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -10,13 +10,16 @@ datasource db {
 }
 
 model User {
-  id            String         @id @default(cuid())
-  email         String         @unique
-  password      String
-  habits        Habit[]
-  refreshTokens RefreshToken[]
-  createdAt     DateTime       @default(now())
-  updatedAt     DateTime       @updatedAt
+  id                  String             @id @default(cuid())
+  email               String             @unique
+  password            String
+  // Master switch — lets a user pause every reminder without deleting them.
+  notificationsEnabled Boolean           @default(false)
+  habits              Habit[]
+  refreshTokens       RefreshToken[]
+  notificationRules   NotificationRule[]
+  createdAt           DateTime           @default(now())
+  updatedAt           DateTime           @updatedAt
 }
 
 // Opaque, rotated on every use — only the SHA-256 hash is stored, so a leaked
@@ -52,6 +55,7 @@ model Habit {
   user User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   days HabitDay[]
   logs HabitLog[]
+  notificationRules NotificationRule[]
 }
 
 model HabitDay {
@@ -75,6 +79,28 @@ model HabitLog {
   habit Habit @relation(fields: [habitId], references: [id], onDelete: Cascade)
 
   @@index([habitId, loggedAt])
+}
+
+// A single reminder rule. habitId null = a general reminder (e.g. an
+// end-of-day nudge) not tied to any one habit. Scheduling itself happens
+// entirely on-device (expo-notifications, local notifications) — this table
+// is just the source of truth the app resyncs its local OS schedule from,
+// so rules survive reinstalls/new devices the same way habits do.
+model NotificationRule {
+  id        String        @id @default(cuid())
+  userId    String
+  habitId   String?
+  cadence   FrequencyType // reuses the same DAILY/WEEKLY/MONTHLY/YEARLY vocabulary as Habit.frequencyType
+  hour      Int           // 0-23, local device time
+  minute    Int           // 0-59
+  enabled   Boolean       @default(true)
+  createdAt DateTime      @default(now())
+  updatedAt DateTime      @updatedAt
+
+  user  User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  habit Habit? @relation(fields: [habitId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
 }
 
 enum DayStatus {


### PR DESCRIPTION
## Summary
- Adds a `NotificationRule` model (habit-optional, cadence reuses the existing DAILY/WEEKLY/MONTHLY/YEARLY vocabulary, hour/minute, enabled) plus a master `notificationsEnabled` toggle on `User`
- Delivery is entirely local (expo-notifications, no push infra/server cron needed) — daily/weekly use native repeating triggers, monthly/yearly recompute the real end-of-period date and reschedule each time the app opens
- Permission is requested once, on first launch after login, via a custom prompt before the OS dialog
- New Notification Settings screen (off Profile): master toggle, add/edit/delete reminders (optionally scoped to a specific habit), per-rule enable, and a temporary "Send Test Notification" button to verify delivery without waiting for a real trigger

## Native rebuild required
`expo-notifications` is a native module — this cannot ship via OTA. Needs a fresh `eas build` + TestFlight submission (and an Android rebuild) once merged.

## Database
- Additive migration only (new `NotificationRule` table + one new column on `User`)

## Test plan
- [ ] Fresh login prompts for notification permission once, never again after answering either way
- [ ] Send Test Notification fires ~3s later even with the app backgrounded / phone locked
- [ ] Add a daily reminder, confirm it survives app restart and still fires
- [ ] Add a habit-specific reminder, confirm the notification body names the habit
- [ ] Toggle master switch off, confirm all local notifications are cancelled
- [ ] Remove the test button once real triggers are confirmed working on device